### PR TITLE
add clearing output catalog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,7 @@ endif
 
 # Build binary in ibm-crossplane submodule
 build-crossplane-binary:
+	rm -rf ibm-crossplane/_output/bin/*
 	make -C ibm-crossplane build.all
 
 ############################################################


### PR DESCRIPTION
to ensure that new binaries are built. In case of failure, `docker build` will fail. Without this line, user was not informed about fail and old binaries were used.

https://github.ibm.com/IBMPrivateCloud/roadmap/issues/48837