### PR TITLE
add deleted secret permissions from bundle

### DIFF
--- a/bundle/manifests/ibm-crossplane-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-crossplane-operator.clusterserviceversion.yaml
@@ -150,6 +150,13 @@ spec:
                 - patch
                 - delete
             - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - list
+                - watch
+            - apiGroups:
                 - apiextensions.crossplane.io
                 - pkg.crossplane.io
               resources:


### PR DESCRIPTION
Fixes changes from this epic: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/47139