### PR TITLE
Reduce ClusterRole configmap and lease permissions

### DIFF
--- a/bundle/manifests/ibm-crossplane-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-crossplane-operator.clusterserviceversion.yaml
@@ -643,20 +643,6 @@ spec:
                 - get
             - apiGroups:
                 - ""
-                - coordination.k8s.io
-              resources:
-                - configmaps
-                - leases
-              verbs:
-                - get
-                - list
-                - create
-                - update
-                - patch
-                - watch
-                - delete
-            - apiGroups:
-                - ""
               resources:
                 - events
               verbs:
@@ -841,7 +827,6 @@ spec:
             - apiGroups:
                 - ""
               resources:
-                - configmaps
                 - events
                 - pods
                 - secrets

--- a/bundle/manifests/ibm-crossplane-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-crossplane-operator.clusterserviceversion.yaml
@@ -842,6 +842,14 @@ spec:
                 - update
                 - watch
             - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - create
+                - update
+            - apiGroups:
                 - apps
               resources:
                 - deployments
@@ -871,13 +879,9 @@ spec:
               resources:
                 - leases
               verbs:
-                - create
-                - delete
                 - get
-                - list
-                - patch
+                - create
                 - update
-                - watch
             - apiGroups:
                 - operator.ibm.com
               resources:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: ibm-crossplane-operator-app
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.2.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.3.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2
   operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/config/rbac/clusterrole.yaml
+++ b/config/rbac/clusterrole.yaml
@@ -22,20 +22,6 @@ rules:
   resourceNames:
   - kafkacomposites.shim.bedrock.ibm.com
   - kafkaclaims.shim.bedrock.ibm.com
-- apiGroups:
-  - ""
-  - coordination.k8s.io
-  resources:
-  - configmaps
-  - leases
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - patch
-  - watch
-  - delete
 # for crossplane to register crossplane events
 - apiGroups:
   - ''

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -10,6 +10,7 @@ rules:
   - configmaps
   verbs:
   - get
+  - create
   - update
 - apiGroups:
   - ""

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -10,12 +10,7 @@ rules:
   - configmaps
   verbs:
   - get
-  - list
-  - watch
-  - create
   - update
-  - patch
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,13 +22,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ''
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-- apiGroups:
   - apps
   resources:
   - deployments
@@ -54,11 +47,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ''
   - coordination.k8s.io
   resources:
+  - configmaps
   - leases
   verbs:
   - get
+  - create
   - update
 - apiGroups:
   - operator.ibm.com

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,7 +7,6 @@ rules:
 - apiGroups:
   - ''
   resources:
-  - configmaps
   - events
   - pods
   - secrets
@@ -22,6 +21,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
 - apiGroups:
   - apps
   resources:
@@ -52,13 +58,8 @@ rules:
   resources:
   - leases
   verbs:
-  - create
-  - delete
   - get
-  - list
-  - patch
   - update
-  - watch
 - apiGroups:
   - operator.ibm.com
   resources:


### PR DESCRIPTION
Remove cluster-scope permissions for configmaps and leases, reduce namespace-scope permissions for configmaps and leases to get, create and update.
[#49590](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/49590)