### PR TITLE
Crossplane 1.1 to 1.4.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ibm-crossplane"]
 	path = ibm-crossplane
 	url = https://github.com/IBM/ibm-crossplane
-	branch = master
+	branch = 1.1-to.1.4.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ibm-crossplane"]
 	path = ibm-crossplane
 	url = https://github.com/IBM/ibm-crossplane
-	branch = 1.1-to.1.4.0
+	branch = master

--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ update-submodule:
 
 copy-operator-data: ## Copy files from ibm-crossplane submodule before recreating bundle
 	git submodule update --init --recursive
-	cp ibm-crossplane/cluster/charts/crossplane/crds/* config/crd/bases/
+	cp ibm-crossplane/cluster/crds/* config/crd/bases/
 
 bundle: copy-operator-data kustomize ## Generate bundle manifests and metadata, then validate the generated files
 	$(OPERATOR_SDK) generate kustomize manifests -q

--- a/build/entrypoint
+++ b/build/entrypoint
@@ -9,4 +9,4 @@ if ! whoami &>/dev/null; then
   fi
 fi
 
-exec ${OPERATOR} core start $@
+exec ${OPERATOR} $@

--- a/build/entrypoint
+++ b/build/entrypoint
@@ -9,4 +9,4 @@ if ! whoami &>/dev/null; then
   fi
 fi
 
-exec ${OPERATOR} $@
+exec ${OPERATOR} core start $@

--- a/bundle/manifests/apiextensions.ibm.crossplane.io_compositeresourcedefinitions.yaml
+++ b/bundle/manifests/apiextensions.ibm.crossplane.io_compositeresourcedefinitions.yaml
@@ -19,6 +19,7 @@ spec:
     plural: compositeresourcedefinitions
     shortNames:
     - xrd
+    - xrds
     singular: compositeresourcedefinition
   scope: Cluster
   versions:
@@ -275,7 +276,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: An CompositeResourceDefinition defines a new kind of composite infrastructure resource. The new resource is composed of other composite or managed infrastructure resources.
+        description: 'An CompositeResourceDefinition defines a new kind of composite infrastructure resource. The new resource is composed of other composite or managed infrastructure resources. [DEPRECATED]: Please use the identical v1 API instead. The v1beta1 API is scheduled to be removed in Crossplane v1.6.'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/bundle/manifests/apiextensions.ibm.crossplane.io_compositionrevisions.yaml
+++ b/bundle/manifests/apiextensions.ibm.crossplane.io_compositionrevisions.yaml
@@ -1,0 +1,447 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: ibm-crossplane-operator
+    app.kubernetes.io/managed-by: ibm-crossplane-operator
+    app.kubernetes.io/name: ibm-crossplane
+  name: compositionrevisions.apiextensions.ibm.crossplane.io
+spec:
+  group: apiextensions.ibm.crossplane.io
+  names:
+    categories:
+    - crossplane
+    kind: CompositionRevision
+    listKind: CompositionRevisionList
+    plural: compositionrevisions
+    singular: compositionrevision
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.revision
+      name: REVISION
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Current')].status
+      name: CURRENT
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: A CompositionRevision represents a revision in time of a Composition. Revisions are created by Crossplane; they should be treated as immutable.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CompositionRevisionSpec specifies the desired state of the composition revision.
+            properties:
+              compositeTypeRef:
+                description: CompositeTypeRef specifies the type of composite resource that this composition is compatible with.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the type.
+                    type: string
+                  kind:
+                    description: Kind of the type.
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                type: object
+              patchSets:
+                description: PatchSets define a named set of patches that may be included by any resource in this Composition. PatchSets cannot themselves refer to other PatchSets.
+                items:
+                  description: A PatchSet is a set of patches that can be reused from all resources within a Composition.
+                  properties:
+                    name:
+                      description: Name of this PatchSet.
+                      type: string
+                    patches:
+                      description: Patches will be applied as an overlay to the base resource.
+                      items:
+                        description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
+                        properties:
+                          combine:
+                            description: Combine is the patch configuration for a CombineFromComposite or CombineToComposite patch.
+                            properties:
+                              strategy:
+                                description: Strategy defines the strategy to use to combine the input variable values. Currently only string is supported.
+                                enum:
+                                - string
+                                type: string
+                              string:
+                                description: String declares that input variables should be combined into a single string, using the relevant settings for formatting purposes.
+                                properties:
+                                  fmt:
+                                    description: Format the input using a Go format string. See https://golang.org/pkg/fmt/ for details.
+                                    type: string
+                                required:
+                                - fmt
+                                type: object
+                              variables:
+                                description: Variables are the list of variables whose values will be retrieved and combined.
+                                items:
+                                  description: A CombineVariable defines the source of a value that is combined with others to form and patch an output value. Currently, this only supports retrieving values from a field path.
+                                  properties:
+                                    fromFieldPath:
+                                      description: FromFieldPath is the path of the field on the source whose value is to be used as input.
+                                      type: string
+                                  required:
+                                  - fromFieldPath
+                                  type: object
+                                minItems: 1
+                                type: array
+                            required:
+                            - strategy
+                            - variables
+                            type: object
+                          fromFieldPath:
+                            description: FromFieldPath is the path of the field on the resource whose value is to be used as input. Required when type is FromCompositeFieldPath or ToCompositeFieldPath.
+                            type: string
+                          patchSetName:
+                            description: PatchSetName to include patches from. Required when type is PatchSet.
+                            type: string
+                          policy:
+                            description: Policy configures the specifics of patching behaviour.
+                            properties:
+                              fromFieldPath:
+                                description: FromFieldPath specifies how to patch from a field path. The default is 'Optional', which means the patch will be a no-op if the specified fromFieldPath does not exist. Use 'Required' if the patch should fail if the specified path does not exist.
+                                enum:
+                                - Optional
+                                - Required
+                                type: string
+                            type: object
+                          toFieldPath:
+                            description: ToFieldPath is the path of the field on the resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path as fromFieldPath.
+                            type: string
+                          transforms:
+                            description: Transforms are the list of functions that are used as a FIFO pipe for the input to be transformed.
+                            items:
+                              description: Transform is a unit of process whose input is transformed into an output with the supplied configuration.
+                              properties:
+                                convert:
+                                  description: Convert is used to cast the input into the given output type.
+                                  properties:
+                                    toType:
+                                      description: ToType is the type of the output of this transform.
+                                      enum:
+                                      - string
+                                      - int
+                                      - int64
+                                      - bool
+                                      - float64
+                                      type: string
+                                  required:
+                                  - toType
+                                  type: object
+                                map:
+                                  additionalProperties:
+                                    type: string
+                                  description: Map uses the input as a key in the given map and returns the value.
+                                  type: object
+                                math:
+                                  description: Math is used to transform the input via mathematical operations such as multiplication.
+                                  properties:
+                                    multiply:
+                                      description: Multiply the value.
+                                      format: int64
+                                      type: integer
+                                  type: object
+                                string:
+                                  description: String is used to transform the input into a string or a different kind of string. Note that the input does not necessarily need to be a string.
+                                  properties:
+                                    fmt:
+                                      description: Format the input using a Go format string. See https://golang.org/pkg/fmt/ for details.
+                                      type: string
+                                  required:
+                                  - fmt
+                                  type: object
+                                type:
+                                  description: Type of the transform to be run.
+                                  enum:
+                                  - map
+                                  - math
+                                  - string
+                                  - convert
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            type: array
+                          type:
+                            default: FromCompositeFieldPath
+                            description: Type sets the patching behaviour to be used. Each patch type may require its' own fields to be set on the Patch object.
+                            enum:
+                            - FromCompositeFieldPath
+                            - PatchSet
+                            - ToCompositeFieldPath
+                            - CombineFromComposite
+                            - CombineToComposite
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  - patches
+                  type: object
+                type: array
+              resources:
+                description: Resources is the list of resource templates that will be used when a composite resource referring to this composition is created.
+                items:
+                  description: ComposedTemplate is used to provide information about how the composed resource should be processed.
+                  properties:
+                    base:
+                      description: Base is the target resource that the patches will be applied on.
+                      type: object
+                      x-kubernetes-embedded-resource: true
+                      x-kubernetes-preserve-unknown-fields: true
+                    connectionDetails:
+                      description: ConnectionDetails lists the propagation secret keys from this target resource to the composition instance connection secret.
+                      items:
+                        description: ConnectionDetail includes the information about the propagation of the connection information from one secret to another.
+                        properties:
+                          fromConnectionSecretKey:
+                            description: FromConnectionSecretKey is the key that will be used to fetch the value from the given target resource's secret.
+                            type: string
+                          fromFieldPath:
+                            description: FromFieldPath is the path of the field on the composed resource whose value to be used as input. Name must be specified if the type is FromFieldPath is specified.
+                            type: string
+                          name:
+                            description: Name of the connection secret key that will be propagated to the connection secret of the composition instance. Leave empty if you'd like to use the same key name.
+                            type: string
+                          type:
+                            description: Type sets the connection detail fetching behaviour to be used. Each connection detail type may require its own fields to be set on the ConnectionDetail object. If the type is omitted Crossplane will attempt to infer it based on which other fields were specified.
+                            enum:
+                            - FromConnectionSecretKey
+                            - FromFieldPath
+                            - FromValue
+                            type: string
+                          value:
+                            description: Value that will be propagated to the connection secret of the composition instance. Typically you should use FromConnectionSecretKey instead, but an explicit value may be set to inject a fixed, non-sensitive connection secret values, for example a well-known port. Supercedes FromConnectionSecretKey when set.
+                            type: string
+                        type: object
+                      type: array
+                    name:
+                      description: A Name uniquely identifies this entry within its Composition's resources array. Names are optional but *strongly* recommended. When all entries in the resources array are named entries may added, deleted, and reordered as long as their names do not change. When entries are not named the length and order of the resources array should be treated as immutable. Either all or no entries must be named.
+                      type: string
+                    patches:
+                      description: Patches will be applied as overlay to the base resource.
+                      items:
+                        description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
+                        properties:
+                          combine:
+                            description: Combine is the patch configuration for a CombineFromComposite or CombineToComposite patch.
+                            properties:
+                              strategy:
+                                description: Strategy defines the strategy to use to combine the input variable values. Currently only string is supported.
+                                enum:
+                                - string
+                                type: string
+                              string:
+                                description: String declares that input variables should be combined into a single string, using the relevant settings for formatting purposes.
+                                properties:
+                                  fmt:
+                                    description: Format the input using a Go format string. See https://golang.org/pkg/fmt/ for details.
+                                    type: string
+                                required:
+                                - fmt
+                                type: object
+                              variables:
+                                description: Variables are the list of variables whose values will be retrieved and combined.
+                                items:
+                                  description: A CombineVariable defines the source of a value that is combined with others to form and patch an output value. Currently, this only supports retrieving values from a field path.
+                                  properties:
+                                    fromFieldPath:
+                                      description: FromFieldPath is the path of the field on the source whose value is to be used as input.
+                                      type: string
+                                  required:
+                                  - fromFieldPath
+                                  type: object
+                                minItems: 1
+                                type: array
+                            required:
+                            - strategy
+                            - variables
+                            type: object
+                          fromFieldPath:
+                            description: FromFieldPath is the path of the field on the resource whose value is to be used as input. Required when type is FromCompositeFieldPath or ToCompositeFieldPath.
+                            type: string
+                          patchSetName:
+                            description: PatchSetName to include patches from. Required when type is PatchSet.
+                            type: string
+                          policy:
+                            description: Policy configures the specifics of patching behaviour.
+                            properties:
+                              fromFieldPath:
+                                description: FromFieldPath specifies how to patch from a field path. The default is 'Optional', which means the patch will be a no-op if the specified fromFieldPath does not exist. Use 'Required' if the patch should fail if the specified path does not exist.
+                                enum:
+                                - Optional
+                                - Required
+                                type: string
+                            type: object
+                          toFieldPath:
+                            description: ToFieldPath is the path of the field on the resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path as fromFieldPath.
+                            type: string
+                          transforms:
+                            description: Transforms are the list of functions that are used as a FIFO pipe for the input to be transformed.
+                            items:
+                              description: Transform is a unit of process whose input is transformed into an output with the supplied configuration.
+                              properties:
+                                convert:
+                                  description: Convert is used to cast the input into the given output type.
+                                  properties:
+                                    toType:
+                                      description: ToType is the type of the output of this transform.
+                                      enum:
+                                      - string
+                                      - int
+                                      - int64
+                                      - bool
+                                      - float64
+                                      type: string
+                                  required:
+                                  - toType
+                                  type: object
+                                map:
+                                  additionalProperties:
+                                    type: string
+                                  description: Map uses the input as a key in the given map and returns the value.
+                                  type: object
+                                math:
+                                  description: Math is used to transform the input via mathematical operations such as multiplication.
+                                  properties:
+                                    multiply:
+                                      description: Multiply the value.
+                                      format: int64
+                                      type: integer
+                                  type: object
+                                string:
+                                  description: String is used to transform the input into a string or a different kind of string. Note that the input does not necessarily need to be a string.
+                                  properties:
+                                    fmt:
+                                      description: Format the input using a Go format string. See https://golang.org/pkg/fmt/ for details.
+                                      type: string
+                                  required:
+                                  - fmt
+                                  type: object
+                                type:
+                                  description: Type of the transform to be run.
+                                  enum:
+                                  - map
+                                  - math
+                                  - string
+                                  - convert
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            type: array
+                          type:
+                            default: FromCompositeFieldPath
+                            description: Type sets the patching behaviour to be used. Each patch type may require its' own fields to be set on the Patch object.
+                            enum:
+                            - FromCompositeFieldPath
+                            - PatchSet
+                            - ToCompositeFieldPath
+                            - CombineFromComposite
+                            - CombineToComposite
+                            type: string
+                        type: object
+                      type: array
+                    readinessChecks:
+                      description: ReadinessChecks allows users to define custom readiness checks. All checks have to return true in order for resource to be considered ready. The default readiness check is to have the "Ready" condition to be "True".
+                      items:
+                        description: ReadinessCheck is used to indicate how to tell whether a resource is ready for consumption
+                        properties:
+                          fieldPath:
+                            description: FieldPath shows the path of the field whose value will be used.
+                            type: string
+                          matchInteger:
+                            description: MatchInt is the value you'd like to match if you're using "MatchInt" type.
+                            format: int64
+                            type: integer
+                          matchString:
+                            description: MatchString is the value you'd like to match if you're using "MatchString" type.
+                            type: string
+                          type:
+                            description: Type indicates the type of probe you'd like to use.
+                            enum:
+                            - MatchString
+                            - MatchInteger
+                            - NonEmpty
+                            - None
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      type: array
+                  required:
+                  - base
+                  type: object
+                type: array
+              revision:
+                description: Revision number. Newer revisions have larger numbers.
+                format: int64
+                type: integer
+              writeConnectionSecretsToNamespace:
+                description: WriteConnectionSecretsToNamespace specifies the namespace in which the connection secrets of composite resource dynamically provisioned using this composition will be created.
+                type: string
+            required:
+            - compositeTypeRef
+            - resources
+            - revision
+            type: object
+          status:
+            description: CompositionRevisionStatus shows the observed state of the composition revision.
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True, False, or Unknown?
+                      type: string
+                    type:
+                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/manifests/apiextensions.ibm.crossplane.io_compositions.yaml
+++ b/bundle/manifests/apiextensions.ibm.crossplane.io_compositions.yaml
@@ -27,7 +27,7 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: Composition defines the group of resources to be created when a compatible type is created with reference to the composition.
+        description: A Composition specifies how a composite resource should be composed.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -38,7 +38,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: CompositionSpec specifies the desired state of the definition.
+            description: CompositionSpec specifies desired state of a composition.
             properties:
               compositeTypeRef:
                 description: CompositeTypeRef specifies the type of composite resource that this composition is compatible with.
@@ -66,6 +66,40 @@ spec:
                       items:
                         description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
                         properties:
+                          combine:
+                            description: Combine is the patch configuration for a CombineFromComposite or CombineToComposite patch.
+                            properties:
+                              strategy:
+                                description: Strategy defines the strategy to use to combine the input variable values. Currently only string is supported.
+                                enum:
+                                - string
+                                type: string
+                              string:
+                                description: String declares that input variables should be combined into a single string, using the relevant settings for formatting purposes.
+                                properties:
+                                  fmt:
+                                    description: Format the input using a Go format string. See https://golang.org/pkg/fmt/ for details.
+                                    type: string
+                                required:
+                                - fmt
+                                type: object
+                              variables:
+                                description: Variables are the list of variables whose values will be retrieved and combined.
+                                items:
+                                  description: A CombineVariable defines the source of a value that is combined with others to form and patch an output value. Currently, this only supports retrieving values from a field path.
+                                  properties:
+                                    fromFieldPath:
+                                      description: FromFieldPath is the path of the field on the source whose value is to be used as input.
+                                      type: string
+                                  required:
+                                  - fromFieldPath
+                                  type: object
+                                minItems: 1
+                                type: array
+                            required:
+                            - strategy
+                            - variables
+                            type: object
                           fromFieldPath:
                             description: FromFieldPath is the path of the field on the resource whose value is to be used as input. Required when type is FromCompositeFieldPath or ToCompositeFieldPath.
                             type: string
@@ -81,6 +115,16 @@ spec:
                                 - Optional
                                 - Required
                                 type: string
+                              mergeOptions:
+                                description: MergeOptions Specifies merge options on a field path
+                                properties:
+                                  appendSlice:
+                                    description: Specifies that already existing elements in a merged slice should be preserved
+                                    type: boolean
+                                  keepMapValues:
+                                    description: Specifies that already existing values in a merged map should be preserved
+                                    type: boolean
+                                type: object
                             type: object
                           toFieldPath:
                             description: ToFieldPath is the path of the field on the resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path as fromFieldPath.
@@ -98,6 +142,7 @@ spec:
                                       enum:
                                       - string
                                       - int
+                                      - int64
                                       - bool
                                       - float64
                                       type: string
@@ -145,6 +190,8 @@ spec:
                             - FromCompositeFieldPath
                             - PatchSet
                             - ToCompositeFieldPath
+                            - CombineFromComposite
+                            - CombineToComposite
                             type: string
                         type: object
                       type: array
@@ -197,6 +244,40 @@ spec:
                       items:
                         description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
                         properties:
+                          combine:
+                            description: Combine is the patch configuration for a CombineFromComposite or CombineToComposite patch.
+                            properties:
+                              strategy:
+                                description: Strategy defines the strategy to use to combine the input variable values. Currently only string is supported.
+                                enum:
+                                - string
+                                type: string
+                              string:
+                                description: String declares that input variables should be combined into a single string, using the relevant settings for formatting purposes.
+                                properties:
+                                  fmt:
+                                    description: Format the input using a Go format string. See https://golang.org/pkg/fmt/ for details.
+                                    type: string
+                                required:
+                                - fmt
+                                type: object
+                              variables:
+                                description: Variables are the list of variables whose values will be retrieved and combined.
+                                items:
+                                  description: A CombineVariable defines the source of a value that is combined with others to form and patch an output value. Currently, this only supports retrieving values from a field path.
+                                  properties:
+                                    fromFieldPath:
+                                      description: FromFieldPath is the path of the field on the source whose value is to be used as input.
+                                      type: string
+                                  required:
+                                  - fromFieldPath
+                                  type: object
+                                minItems: 1
+                                type: array
+                            required:
+                            - strategy
+                            - variables
+                            type: object
                           fromFieldPath:
                             description: FromFieldPath is the path of the field on the resource whose value is to be used as input. Required when type is FromCompositeFieldPath or ToCompositeFieldPath.
                             type: string
@@ -212,6 +293,16 @@ spec:
                                 - Optional
                                 - Required
                                 type: string
+                              mergeOptions:
+                                description: MergeOptions Specifies merge options on a field path
+                                properties:
+                                  appendSlice:
+                                    description: Specifies that already existing elements in a merged slice should be preserved
+                                    type: boolean
+                                  keepMapValues:
+                                    description: Specifies that already existing values in a merged map should be preserved
+                                    type: boolean
+                                type: object
                             type: object
                           toFieldPath:
                             description: ToFieldPath is the path of the field on the resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path as fromFieldPath.
@@ -229,6 +320,7 @@ spec:
                                       enum:
                                       - string
                                       - int
+                                      - int64
                                       - bool
                                       - float64
                                       type: string
@@ -276,6 +368,8 @@ spec:
                             - FromCompositeFieldPath
                             - PatchSet
                             - ToCompositeFieldPath
+                            - CombineFromComposite
+                            - CombineToComposite
                             type: string
                         type: object
                       type: array
@@ -317,43 +411,10 @@ spec:
             - compositeTypeRef
             - resources
             type: object
-          status:
-            description: CompositionStatus shows the observed state of the composition.
-            properties:
-              conditions:
-                description: Conditions of the resource.
-                items:
-                  description: A Condition that may apply to a resource.
-                  properties:
-                    lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
-                      format: date-time
-                      type: string
-                    message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
-                      type: string
-                    reason:
-                      description: A Reason for this condition's last transition from one status to another.
-                      type: string
-                    status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
-                      type: string
-                    type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-            type: object
         type: object
     served: true
     storage: true
-    subresources:
-      status: {}
+    subresources: {}
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
@@ -361,7 +422,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Composition defines the group of resources to be created when a compatible type is created with reference to the composition.
+        description: 'Composition defines the group of resources to be created when a compatible type is created with reference to the composition. [DEPRECATED]: Please use the identical v1 API instead. The v1beta1 API is scheduled to be removed in Crossplane v1.6.'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -372,7 +433,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: CompositionSpec specifies the desired state of the definition.
+            description: CompositionSpec specifies the desired state of the composition.
             properties:
               compositeTypeRef:
                 description: CompositeTypeRef specifies the type of composite resource that this composition is compatible with.
@@ -400,6 +461,40 @@ spec:
                       items:
                         description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
                         properties:
+                          combine:
+                            description: Combine is the patch configuration for a CombineFromComposite or CombineToComposite patch.
+                            properties:
+                              strategy:
+                                description: Strategy defines the strategy to use to combine the input variable values. Currently only string is supported.
+                                enum:
+                                - string
+                                type: string
+                              string:
+                                description: String declares that input variables should be combined into a single string, using the relevant settings for formatting purposes.
+                                properties:
+                                  fmt:
+                                    description: Format the input using a Go format string. See https://golang.org/pkg/fmt/ for details.
+                                    type: string
+                                required:
+                                - fmt
+                                type: object
+                              variables:
+                                description: Variables are the list of variables whose values will be retrieved and combined.
+                                items:
+                                  description: A CombineVariable defines the source of a value that is combined with others to form and patch an output value. Currently, this only supports retrieving values from a field path.
+                                  properties:
+                                    fromFieldPath:
+                                      description: FromFieldPath is the path of the field on the source whose value is to be used as input.
+                                      type: string
+                                  required:
+                                  - fromFieldPath
+                                  type: object
+                                minItems: 1
+                                type: array
+                            required:
+                            - strategy
+                            - variables
+                            type: object
                           fromFieldPath:
                             description: FromFieldPath is the path of the field on the resource whose value is to be used as input. Required when type is FromCompositeFieldPath or ToCompositeFieldPath.
                             type: string
@@ -415,6 +510,16 @@ spec:
                                 - Optional
                                 - Required
                                 type: string
+                              mergeOptions:
+                                description: MergeOptions Specifies merge options on a field path
+                                properties:
+                                  appendSlice:
+                                    description: Specifies that already existing elements in a merged slice should be preserved
+                                    type: boolean
+                                  keepMapValues:
+                                    description: Specifies that already existing values in a merged map should be preserved
+                                    type: boolean
+                                type: object
                             type: object
                           toFieldPath:
                             description: ToFieldPath is the path of the field on the resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path as fromFieldPath.
@@ -479,6 +584,8 @@ spec:
                             - FromCompositeFieldPath
                             - PatchSet
                             - ToCompositeFieldPath
+                            - CombineFromComposite
+                            - CombineToComposite
                             type: string
                         type: object
                       type: array
@@ -531,6 +638,40 @@ spec:
                       items:
                         description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
                         properties:
+                          combine:
+                            description: Combine is the patch configuration for a CombineFromComposite or CombineToComposite patch.
+                            properties:
+                              strategy:
+                                description: Strategy defines the strategy to use to combine the input variable values. Currently only string is supported.
+                                enum:
+                                - string
+                                type: string
+                              string:
+                                description: String declares that input variables should be combined into a single string, using the relevant settings for formatting purposes.
+                                properties:
+                                  fmt:
+                                    description: Format the input using a Go format string. See https://golang.org/pkg/fmt/ for details.
+                                    type: string
+                                required:
+                                - fmt
+                                type: object
+                              variables:
+                                description: Variables are the list of variables whose values will be retrieved and combined.
+                                items:
+                                  description: A CombineVariable defines the source of a value that is combined with others to form and patch an output value. Currently, this only supports retrieving values from a field path.
+                                  properties:
+                                    fromFieldPath:
+                                      description: FromFieldPath is the path of the field on the source whose value is to be used as input.
+                                      type: string
+                                  required:
+                                  - fromFieldPath
+                                  type: object
+                                minItems: 1
+                                type: array
+                            required:
+                            - strategy
+                            - variables
+                            type: object
                           fromFieldPath:
                             description: FromFieldPath is the path of the field on the resource whose value is to be used as input. Required when type is FromCompositeFieldPath or ToCompositeFieldPath.
                             type: string
@@ -546,6 +687,16 @@ spec:
                                 - Optional
                                 - Required
                                 type: string
+                              mergeOptions:
+                                description: MergeOptions Specifies merge options on a field path
+                                properties:
+                                  appendSlice:
+                                    description: Specifies that already existing elements in a merged slice should be preserved
+                                    type: boolean
+                                  keepMapValues:
+                                    description: Specifies that already existing values in a merged map should be preserved
+                                    type: boolean
+                                type: object
                             type: object
                           toFieldPath:
                             description: ToFieldPath is the path of the field on the resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path as fromFieldPath.
@@ -610,6 +761,8 @@ spec:
                             - FromCompositeFieldPath
                             - PatchSet
                             - ToCompositeFieldPath
+                            - CombineFromComposite
+                            - CombineToComposite
                             type: string
                         type: object
                       type: array
@@ -650,38 +803,6 @@ spec:
             required:
             - compositeTypeRef
             - resources
-            type: object
-          status:
-            description: CompositionStatus shows the observed state of the composition.
-            properties:
-              conditions:
-                description: Conditions of the resource.
-                items:
-                  description: A Condition that may apply to a resource.
-                  properties:
-                    lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
-                      format: date-time
-                      type: string
-                    message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
-                      type: string
-                    reason:
-                      description: A Reason for this condition's last transition from one status to another.
-                      type: string
-                    status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
-                      type: string
-                    type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
             type: object
         type: object
     served: true

--- a/bundle/manifests/ibm-crossplane-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-crossplane-operator.clusterserviceversion.yaml
@@ -521,6 +521,9 @@ spec:
       - kind: CompositeResourceDefinition
         name: compositeresourcedefinitions.apiextensions.ibm.crossplane.io
         version: v1beta1
+      - kind: CompositionRevision
+        name: compositionrevisions.apiextensions.ibm.crossplane.io
+        version: v1alpha1
       - kind: Composition
         name: compositions.apiextensions.ibm.crossplane.io
         version: v1
@@ -548,6 +551,9 @@ spec:
       - kind: KafkaComposite
         name: kafkacomposites.shim.bedrock.ibm.com
         version: v1alpha1
+      - kind: Lock
+        name: locks.pkg.ibm.crossplane.io
+        version: v1beta1
       - kind: Lock
         name: locks.pkg.ibm.crossplane.io
         version: v1alpha1
@@ -757,7 +763,10 @@ spec:
                           topologyKey: kubernetes.io/hostname
                         weight: 100
                 containers:
-                  - env:
+                  - args:
+                      - core
+                      - start
+                    env:
                       - name: WATCH_NAMESPACE
                         valueFrom:
                           fieldRef:

--- a/bundle/manifests/pkg.ibm.crossplane.io_configurationrevisions.yaml
+++ b/bundle/manifests/pkg.ibm.crossplane.io_configurationrevisions.yaml
@@ -14,6 +14,7 @@ spec:
   names:
     categories:
     - crossplane
+    - pkgrev
     kind: ConfigurationRevision
     listKind: ConfigurationRevisionList
     plural: configurationrevisions
@@ -242,7 +243,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: A ConfigurationRevision that has been added to Crossplane.
+        description: 'A ConfigurationRevision that has been added to Crossplane. [DEPRECATED]: Please use the identical v1 API instead. The v1beta1 API is scheduled to be removed in Crossplane v1.6.'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/bundle/manifests/pkg.ibm.crossplane.io_configurations.yaml
+++ b/bundle/manifests/pkg.ibm.crossplane.io_configurations.yaml
@@ -146,7 +146,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Configuration is the CRD type for a request to add a configuration to Crossplane.
+        description: 'Configuration is the CRD type for a request to add a configuration to Crossplane. [DEPRECATED]: Please use the identical v1 API instead. The v1beta1 API is scheduled to be removed in Crossplane v1.6.'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/bundle/manifests/pkg.ibm.crossplane.io_controllerconfigs.yaml
+++ b/bundle/manifests/pkg.ibm.crossplane.io_controllerconfigs.yaml
@@ -201,8 +201,38 @@ spec:
                                       description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
                                 namespaces:
-                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
@@ -256,8 +286,38 @@ spec:
                                   description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
                             namespaces:
-                              description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
                               items:
                                 type: string
                               type: array
@@ -310,8 +370,38 @@ spec:
                                       description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
                                 namespaces:
-                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
@@ -365,8 +455,38 @@ spec:
                                   description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is alpha-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
                             namespaces:
-                              description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
                               items:
                                 type: string
                               type: array
@@ -518,6 +638,11 @@ spec:
                       type: string
                     description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
                     type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. This will only affect labels on the pod, not the pod selector. Labels will be merged with internal labels used by crossplane, and labels with a crossplane.io key might be overwritten. More info: http://kubernetes.io/docs/user-guide/labels'
+                    type: object
                 type: object
               nodeName:
                 description: NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
@@ -655,7 +780,7 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                   requests:
                     additionalProperties:
@@ -664,7 +789,7 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               runtimeClassName:

--- a/bundle/manifests/pkg.ibm.crossplane.io_locks.yaml
+++ b/bundle/manifests/pkg.ibm.crossplane.io_locks.yaml
@@ -25,6 +25,72 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: 'Lock is the CRD type that tracks package dependencies. [DEPRECATED]: Please use the identical v1beta1 API instead. The v1alpha1 API is scheduled to be removed in Crossplane v1.7.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          packages:
+            items:
+              description: LockPackage is a package that is in the lock.
+              properties:
+                dependencies:
+                  description: Dependencies are the list of dependencies of this package. The order of the dependencies will dictate the order in which they are resolved.
+                  items:
+                    description: A Dependency is a dependency of a package in the lock.
+                    properties:
+                      constraints:
+                        description: Constraints is a valid semver range, which will be used to select a valid dependency version.
+                        type: string
+                      package:
+                        description: Package is the OCI image name without a tag or digest.
+                        type: string
+                      type:
+                        description: Type is the type of package. Can be either Configuration or Provider.
+                        type: string
+                    required:
+                    - constraints
+                    - package
+                    - type
+                    type: object
+                  type: array
+                name:
+                  description: Name corresponds to the name of the package revision for this package.
+                  type: string
+                source:
+                  description: Source is the OCI image name without a tag or digest.
+                  type: string
+                type:
+                  description: Type is the type of package. Can be either Configuration or Provider.
+                  type: string
+                version:
+                  description: Version is the tag or digest of the OCI image.
+                  type: string
+              required:
+              - dependencies
+              - name
+              - source
+              - type
+              - version
+              type: object
+            type: array
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
         description: Lock is the CRD type that tracks package dependencies.
         properties:
           apiVersion:

--- a/bundle/manifests/pkg.ibm.crossplane.io_providerrevisions.yaml
+++ b/bundle/manifests/pkg.ibm.crossplane.io_providerrevisions.yaml
@@ -14,6 +14,7 @@ spec:
   names:
     categories:
     - crossplane
+    - pkgrev
     kind: ProviderRevision
     listKind: ProviderRevisionList
     plural: providerrevisions
@@ -242,7 +243,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: A ProviderRevision that has been added to Crossplane.
+        description: 'A ProviderRevision that has been added to Crossplane. [DEPRECATED]: Please use the identical v1 API instead. The v1beta1 API is scheduled to be removed in Crossplane v1.6.'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/bundle/manifests/pkg.ibm.crossplane.io_providers.yaml
+++ b/bundle/manifests/pkg.ibm.crossplane.io_providers.yaml
@@ -155,7 +155,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Provider is the CRD type for a request to add a provider to Crossplane.
+        description: 'Provider is the CRD type for a request to add a provider to Crossplane. [DEPRECATED]: Please use the identical v1 API instead. The v1beta1 API is scheduled to be removed in Crossplane v1.6.'
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/config/crd/bases/apiextensions.ibm.crossplane.io_compositeresourcedefinitions.yaml
+++ b/config/crd/bases/apiextensions.ibm.crossplane.io_compositeresourcedefinitions.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/config/crd/bases/apiextensions.ibm.crossplane.io_compositeresourcedefinitions.yaml
+++ b/config/crd/bases/apiextensions.ibm.crossplane.io_compositeresourcedefinitions.yaml
@@ -17,6 +17,7 @@ spec:
     plural: compositeresourcedefinitions
     shortNames:
     - xrd
+    - xrds
     singular: compositeresourcedefinition
   scope: Cluster
   versions:
@@ -33,55 +34,83 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: An CompositeResourceDefinition defines a new kind of composite infrastructure resource. The new resource is composed of other composite or managed infrastructure resources.
+        description: An CompositeResourceDefinition defines a new kind of composite
+          infrastructure resource. The new resource is composed of other composite
+          or managed infrastructure resources.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: CompositeResourceDefinitionSpec specifies the desired state of the definition.
+            description: CompositeResourceDefinitionSpec specifies the desired state
+              of the definition.
             properties:
               claimNames:
-                description: ClaimNames specifies the names of an optional composite resource claim. When claim names are specified Crossplane will create a namespaced 'composite resource claim' CRD that corresponds to the defined composite resource. This composite resource claim acts as a namespaced proxy for the composite resource; creating, updating, or deleting the claim will create, update, or delete a corresponding composite resource. You may add claim names to an existing CompositeResourceDefinition, but they cannot be changed or removed once they have been set.
+                description: ClaimNames specifies the names of an optional composite
+                  resource claim. When claim names are specified Crossplane will create
+                  a namespaced 'composite resource claim' CRD that corresponds to
+                  the defined composite resource. This composite resource claim acts
+                  as a namespaced proxy for the composite resource; creating, updating,
+                  or deleting the claim will create, update, or delete a corresponding
+                  composite resource. You may add claim names to an existing CompositeResourceDefinition,
+                  but they cannot be changed or removed once they have been set.
                 properties:
                   categories:
-                    description: categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
+                    description: categories is a list of grouped resources this custom
+                      resource belongs to (e.g. 'all'). This is published in API discovery
+                      documents, and used by clients to support invocations like `kubectl
+                      get all`.
                     items:
                       type: string
                     type: array
                   kind:
-                    description: kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
+                    description: kind is the serialized kind of the resource. It is
+                      normally CamelCase and singular. Custom resource instances will
+                      use this value as the `kind` attribute in API calls.
                     type: string
                   listKind:
-                    description: listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
+                    description: listKind is the serialized kind of the list for this
+                      resource. Defaults to "`kind`List".
                     type: string
                   plural:
-                    description: plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
+                    description: plural is the plural name of the resource to serve.
+                      The custom resources are served under `/apis/<group>/<version>/.../<plural>`.
+                      Must match the name of the CustomResourceDefinition (in the
+                      form `<names.plural>.<group>`). Must be all lowercase.
                     type: string
                   shortNames:
-                    description: shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
+                    description: shortNames are short names for the resource, exposed
+                      in API discovery documents, and used by clients to support invocations
+                      like `kubectl get <shortname>`. It must be all lowercase.
                     items:
                       type: string
                     type: array
                   singular:
-                    description: singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+                    description: singular is the singular name of the resource. It
+                      must be all lowercase. Defaults to lowercased `kind`.
                     type: string
                 required:
                 - kind
                 - plural
                 type: object
               connectionSecretKeys:
-                description: ConnectionSecretKeys is the list of keys that will be exposed to the end user of the defined kind.
+                description: ConnectionSecretKeys is the list of keys that will be
+                  exposed to the end user of the defined kind.
                 items:
                   type: string
                 type: array
               defaultCompositionRef:
-                description: DefaultCompositionRef refers to the Composition resource that will be used in case no composition selector is given.
+                description: DefaultCompositionRef refers to the Composition resource
+                  that will be used in case no composition selector is given.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -90,7 +119,9 @@ spec:
                 - name
                 type: object
               enforcedCompositionRef:
-                description: EnforcedCompositionRef refers to the Composition resource that will be used by all composite instances whose schema is defined by this definition.
+                description: EnforcedCompositionRef refers to the Composition resource
+                  that will be used by all composite instances whose schema is defined
+                  by this definition.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -99,65 +130,111 @@ spec:
                 - name
                 type: object
               group:
-                description: Group specifies the API group of the defined composite resource. Composite resources are served under `/apis/<group>/...`. Must match the name of the XRD (in the form `<names.plural>.<group>`).
+                description: Group specifies the API group of the defined composite
+                  resource. Composite resources are served under `/apis/<group>/...`.
+                  Must match the name of the XRD (in the form `<names.plural>.<group>`).
                 type: string
               names:
-                description: Names specifies the resource and kind names of the defined composite resource.
+                description: Names specifies the resource and kind names of the defined
+                  composite resource.
                 properties:
                   categories:
-                    description: categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
+                    description: categories is a list of grouped resources this custom
+                      resource belongs to (e.g. 'all'). This is published in API discovery
+                      documents, and used by clients to support invocations like `kubectl
+                      get all`.
                     items:
                       type: string
                     type: array
                   kind:
-                    description: kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
+                    description: kind is the serialized kind of the resource. It is
+                      normally CamelCase and singular. Custom resource instances will
+                      use this value as the `kind` attribute in API calls.
                     type: string
                   listKind:
-                    description: listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
+                    description: listKind is the serialized kind of the list for this
+                      resource. Defaults to "`kind`List".
                     type: string
                   plural:
-                    description: plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
+                    description: plural is the plural name of the resource to serve.
+                      The custom resources are served under `/apis/<group>/<version>/.../<plural>`.
+                      Must match the name of the CustomResourceDefinition (in the
+                      form `<names.plural>.<group>`). Must be all lowercase.
                     type: string
                   shortNames:
-                    description: shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
+                    description: shortNames are short names for the resource, exposed
+                      in API discovery documents, and used by clients to support invocations
+                      like `kubectl get <shortname>`. It must be all lowercase.
                     items:
                       type: string
                     type: array
                   singular:
-                    description: singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+                    description: singular is the singular name of the resource. It
+                      must be all lowercase. Defaults to lowercased `kind`.
                     type: string
                 required:
                 - kind
                 - plural
                 type: object
               versions:
-                description: 'Versions is the list of all API versions of the defined composite resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10. Note that all versions must have identical schemas; Crossplane does not currently support conversion between different version schemas.'
+                description: 'Versions is the list of all API versions of the defined
+                  composite resource. Version names are used to compute the order
+                  in which served versions are listed in API discovery. If the version
+                  string is "kube-like", it will sort above non "kube-like" version
+                  strings, which are ordered lexicographically. "Kube-like" versions
+                  start with a "v", then are followed by a number (the major version),
+                  then optionally the string "alpha" or "beta" and another number
+                  (the minor version). These are sorted first by GA > beta > alpha
+                  (where GA is a version with no suffix such as beta or alpha), and
+                  then by comparing major version, then minor version. An example
+                  sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1,
+                  v12alpha1, v11alpha2, foo1, foo10. Note that all versions must have
+                  identical schemas; Crossplane does not currently support conversion
+                  between different version schemas.'
                 items:
-                  description: CompositeResourceDefinitionVersion describes a version of an XR.
+                  description: CompositeResourceDefinitionVersion describes a version
+                    of an XR.
                   properties:
                     additionalPrinterColumns:
-                      description: 'AdditionalPrinterColumns specifies additional columns returned in Table output. If no columns are specified, a single column displaying the age of the custom resource is used. See the following link for details: https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables'
+                      description: 'AdditionalPrinterColumns specifies additional
+                        columns returned in Table output. If no columns are specified,
+                        a single column displaying the age of the custom resource
+                        is used. See the following link for details: https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables'
                       items:
-                        description: CustomResourceColumnDefinition specifies a column for server side printing.
+                        description: CustomResourceColumnDefinition specifies a column
+                          for server side printing.
                         properties:
                           description:
-                            description: description is a human readable description of this column.
+                            description: description is a human readable description
+                              of this column.
                             type: string
                           format:
-                            description: format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+                            description: format is an optional OpenAPI type definition
+                              for this column. The 'name' format is applied to the
+                              primary identifier column to assist in clients identifying
+                              column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
+                              for details.
                             type: string
                           jsonPath:
-                            description: jsonPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.
+                            description: jsonPath is a simple JSON path (i.e. with
+                              array notation) which is evaluated against each custom
+                              resource to produce the value for this column.
                             type: string
                           name:
                             description: name is a human readable name for the column.
                             type: string
                           priority:
-                            description: priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.
+                            description: priority is an integer defining the relative
+                              importance of this column compared to others. Lower
+                              numbers are considered higher priority. Columns that
+                              may be omitted in limited space scenarios should be
+                              given a priority greater than 0.
                             format: int32
                             type: integer
                           type:
-                            description: type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+                            description: type is an OpenAPI type definition for this
+                              column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
+                              for details.
                             type: string
                         required:
                         - jsonPath
@@ -166,21 +243,35 @@ spec:
                         type: object
                       type: array
                     name:
-                      description: Name of this version, e.g. “v1”, “v2beta1”, etc. Composite resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.
+                      description: Name of this version, e.g. “v1”, “v2beta1”, etc.
+                        Composite resources are served under this version at `/apis/<group>/<version>/...`
+                        if `served` is true.
                       type: string
                     referenceable:
-                      description: Referenceable specifies that this version may be referenced by a Composition in order to configure which resources an XR may be composed of. Exactly one version must be marked as referenceable; all Compositions must target only the referenceable version. The referenceable version must be served.
+                      description: Referenceable specifies that this version may be
+                        referenced by a Composition in order to configure which resources
+                        an XR may be composed of. Exactly one version must be marked
+                        as referenceable; all Compositions must target only the referenceable
+                        version. The referenceable version must be served.
                       type: boolean
                     schema:
-                      description: Schema describes the schema used for validation, pruning, and defaulting of this version of the defined composite resource. Fields required by all composite resources will be injected into this schema automatically, and will override equivalently named fields in this schema. Omitting this schema results in a schema that contains only the fields required by all composite resources.
+                      description: Schema describes the schema used for validation,
+                        pruning, and defaulting of this version of the defined composite
+                        resource. Fields required by all composite resources will
+                        be injected into this schema automatically, and will override
+                        equivalently named fields in this schema. Omitting this schema
+                        results in a schema that contains only the fields required
+                        by all composite resources.
                       properties:
                         openAPIV3Schema:
-                          description: OpenAPIV3Schema is the OpenAPI v3 schema to use for validation and pruning.
+                          description: OpenAPIV3Schema is the OpenAPI v3 schema to
+                            use for validation and pruning.
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                       type: object
                     served:
-                      description: Served specifies that this version should be served via REST APIs.
+                      description: Served specifies that this version should be served
+                        via REST APIs.
                       type: boolean
                   required:
                   - name
@@ -194,7 +285,8 @@ spec:
             - versions
             type: object
           status:
-            description: CompositeResourceDefinitionStatus shows the observed state of the definition.
+            description: CompositeResourceDefinitionStatus shows the observed state
+              of the definition.
             properties:
               conditions:
                 description: Conditions of the resource.
@@ -202,20 +294,25 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
                       type: string
                     reason:
-                      description: A Reason for this condition's last transition from one status to another.
+                      description: A Reason for this condition's last transition from
+                        one status to another.
                       type: string
                     status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -225,10 +322,16 @@ spec:
                   type: object
                 type: array
               controllers:
-                description: Controllers represents the status of the controllers that power this composite resource definition.
+                description: Controllers represents the status of the controllers
+                  that power this composite resource definition.
                 properties:
                   compositeResourceClaimType:
-                    description: The CompositeResourceClaimTypeRef is the type of composite resource claim that Crossplane is currently reconciling for this definition. Its version will eventually become consistent with the definition's referenceable version. Note that clients may interact with any served type; this is simply the type that Crossplane interacts with.
+                    description: The CompositeResourceClaimTypeRef is the type of
+                      composite resource claim that Crossplane is currently reconciling
+                      for this definition. Its version will eventually become consistent
+                      with the definition's referenceable version. Note that clients
+                      may interact with any served type; this is simply the type that
+                      Crossplane interacts with.
                     properties:
                       apiVersion:
                         description: APIVersion of the type.
@@ -241,7 +344,12 @@ spec:
                     - kind
                     type: object
                   compositeResourceType:
-                    description: The CompositeResourceTypeRef is the type of composite resource that Crossplane is currently reconciling for this definition. Its version will eventually become consistent with the definition's referenceable version. Note that clients may interact with any served type; this is simply the type that Crossplane interacts with.
+                    description: The CompositeResourceTypeRef is the type of composite
+                      resource that Crossplane is currently reconciling for this definition.
+                      Its version will eventually become consistent with the definition's
+                      referenceable version. Note that clients may interact with any
+                      served type; this is simply the type that Crossplane interacts
+                      with.
                     properties:
                       apiVersion:
                         description: APIVersion of the type.
@@ -273,55 +381,85 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: An CompositeResourceDefinition defines a new kind of composite infrastructure resource. The new resource is composed of other composite or managed infrastructure resources.
+        description: 'An CompositeResourceDefinition defines a new kind of composite
+          infrastructure resource. The new resource is composed of other composite
+          or managed infrastructure resources. [DEPRECATED]: Please use the identical
+          v1 API instead. The v1beta1 API is scheduled to be removed in Crossplane
+          v1.6.'
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: CompositeResourceDefinitionSpec specifies the desired state of the definition.
+            description: CompositeResourceDefinitionSpec specifies the desired state
+              of the definition.
             properties:
               claimNames:
-                description: ClaimNames specifies the names of an optional composite resource claim. When claim names are specified Crossplane will create a namespaced 'composite resource claim' CRD that corresponds to the defined composite resource. This composite resource claim acts as a namespaced proxy for the composite resource; creating, updating, or deleting the claim will create, update, or delete a corresponding composite resource. You may add claim names to an existing CompositeResourceDefinition, but they cannot be changed or removed once they have been set.
+                description: ClaimNames specifies the names of an optional composite
+                  resource claim. When claim names are specified Crossplane will create
+                  a namespaced 'composite resource claim' CRD that corresponds to
+                  the defined composite resource. This composite resource claim acts
+                  as a namespaced proxy for the composite resource; creating, updating,
+                  or deleting the claim will create, update, or delete a corresponding
+                  composite resource. You may add claim names to an existing CompositeResourceDefinition,
+                  but they cannot be changed or removed once they have been set.
                 properties:
                   categories:
-                    description: categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
+                    description: categories is a list of grouped resources this custom
+                      resource belongs to (e.g. 'all'). This is published in API discovery
+                      documents, and used by clients to support invocations like `kubectl
+                      get all`.
                     items:
                       type: string
                     type: array
                   kind:
-                    description: kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
+                    description: kind is the serialized kind of the resource. It is
+                      normally CamelCase and singular. Custom resource instances will
+                      use this value as the `kind` attribute in API calls.
                     type: string
                   listKind:
-                    description: listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
+                    description: listKind is the serialized kind of the list for this
+                      resource. Defaults to "`kind`List".
                     type: string
                   plural:
-                    description: plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
+                    description: plural is the plural name of the resource to serve.
+                      The custom resources are served under `/apis/<group>/<version>/.../<plural>`.
+                      Must match the name of the CustomResourceDefinition (in the
+                      form `<names.plural>.<group>`). Must be all lowercase.
                     type: string
                   shortNames:
-                    description: shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
+                    description: shortNames are short names for the resource, exposed
+                      in API discovery documents, and used by clients to support invocations
+                      like `kubectl get <shortname>`. It must be all lowercase.
                     items:
                       type: string
                     type: array
                   singular:
-                    description: singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+                    description: singular is the singular name of the resource. It
+                      must be all lowercase. Defaults to lowercased `kind`.
                     type: string
                 required:
                 - kind
                 - plural
                 type: object
               connectionSecretKeys:
-                description: ConnectionSecretKeys is the list of keys that will be exposed to the end user of the defined kind.
+                description: ConnectionSecretKeys is the list of keys that will be
+                  exposed to the end user of the defined kind.
                 items:
                   type: string
                 type: array
               defaultCompositionRef:
-                description: DefaultCompositionRef refers to the Composition resource that will be used in case no composition selector is given.
+                description: DefaultCompositionRef refers to the Composition resource
+                  that will be used in case no composition selector is given.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -330,7 +468,9 @@ spec:
                 - name
                 type: object
               enforcedCompositionRef:
-                description: EnforcedCompositionRef refers to the Composition resource that will be used by all composite instances whose schema is defined by this definition.
+                description: EnforcedCompositionRef refers to the Composition resource
+                  that will be used by all composite instances whose schema is defined
+                  by this definition.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -339,65 +479,111 @@ spec:
                 - name
                 type: object
               group:
-                description: Group specifies the API group of the defined composite resource. Composite resources are served under `/apis/<group>/...`. Must match the name of the XRD (in the form `<names.plural>.<group>`).
+                description: Group specifies the API group of the defined composite
+                  resource. Composite resources are served under `/apis/<group>/...`.
+                  Must match the name of the XRD (in the form `<names.plural>.<group>`).
                 type: string
               names:
-                description: Names specifies the resource and kind names of the defined composite resource.
+                description: Names specifies the resource and kind names of the defined
+                  composite resource.
                 properties:
                   categories:
-                    description: categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
+                    description: categories is a list of grouped resources this custom
+                      resource belongs to (e.g. 'all'). This is published in API discovery
+                      documents, and used by clients to support invocations like `kubectl
+                      get all`.
                     items:
                       type: string
                     type: array
                   kind:
-                    description: kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
+                    description: kind is the serialized kind of the resource. It is
+                      normally CamelCase and singular. Custom resource instances will
+                      use this value as the `kind` attribute in API calls.
                     type: string
                   listKind:
-                    description: listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
+                    description: listKind is the serialized kind of the list for this
+                      resource. Defaults to "`kind`List".
                     type: string
                   plural:
-                    description: plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
+                    description: plural is the plural name of the resource to serve.
+                      The custom resources are served under `/apis/<group>/<version>/.../<plural>`.
+                      Must match the name of the CustomResourceDefinition (in the
+                      form `<names.plural>.<group>`). Must be all lowercase.
                     type: string
                   shortNames:
-                    description: shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
+                    description: shortNames are short names for the resource, exposed
+                      in API discovery documents, and used by clients to support invocations
+                      like `kubectl get <shortname>`. It must be all lowercase.
                     items:
                       type: string
                     type: array
                   singular:
-                    description: singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+                    description: singular is the singular name of the resource. It
+                      must be all lowercase. Defaults to lowercased `kind`.
                     type: string
                 required:
                 - kind
                 - plural
                 type: object
               versions:
-                description: 'Versions is the list of all API versions of the defined composite resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10. Note that all versions must have identical schemas; Crossplane does not currently support conversion between different version schemas.'
+                description: 'Versions is the list of all API versions of the defined
+                  composite resource. Version names are used to compute the order
+                  in which served versions are listed in API discovery. If the version
+                  string is "kube-like", it will sort above non "kube-like" version
+                  strings, which are ordered lexicographically. "Kube-like" versions
+                  start with a "v", then are followed by a number (the major version),
+                  then optionally the string "alpha" or "beta" and another number
+                  (the minor version). These are sorted first by GA > beta > alpha
+                  (where GA is a version with no suffix such as beta or alpha), and
+                  then by comparing major version, then minor version. An example
+                  sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1,
+                  v12alpha1, v11alpha2, foo1, foo10. Note that all versions must have
+                  identical schemas; Crossplane does not currently support conversion
+                  between different version schemas.'
                 items:
-                  description: CompositeResourceDefinitionVersion describes a version of an XR.
+                  description: CompositeResourceDefinitionVersion describes a version
+                    of an XR.
                   properties:
                     additionalPrinterColumns:
-                      description: 'AdditionalPrinterColumns specifies additional columns returned in Table output. If no columns are specified, a single column displaying the age of the custom resource is used. See the following link for details: https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables'
+                      description: 'AdditionalPrinterColumns specifies additional
+                        columns returned in Table output. If no columns are specified,
+                        a single column displaying the age of the custom resource
+                        is used. See the following link for details: https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables'
                       items:
-                        description: CustomResourceColumnDefinition specifies a column for server side printing.
+                        description: CustomResourceColumnDefinition specifies a column
+                          for server side printing.
                         properties:
                           description:
-                            description: description is a human readable description of this column.
+                            description: description is a human readable description
+                              of this column.
                             type: string
                           format:
-                            description: format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+                            description: format is an optional OpenAPI type definition
+                              for this column. The 'name' format is applied to the
+                              primary identifier column to assist in clients identifying
+                              column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
+                              for details.
                             type: string
                           jsonPath:
-                            description: jsonPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.
+                            description: jsonPath is a simple JSON path (i.e. with
+                              array notation) which is evaluated against each custom
+                              resource to produce the value for this column.
                             type: string
                           name:
                             description: name is a human readable name for the column.
                             type: string
                           priority:
-                            description: priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.
+                            description: priority is an integer defining the relative
+                              importance of this column compared to others. Lower
+                              numbers are considered higher priority. Columns that
+                              may be omitted in limited space scenarios should be
+                              given a priority greater than 0.
                             format: int32
                             type: integer
                           type:
-                            description: type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+                            description: type is an OpenAPI type definition for this
+                              column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
+                              for details.
                             type: string
                         required:
                         - jsonPath
@@ -406,21 +592,35 @@ spec:
                         type: object
                       type: array
                     name:
-                      description: Name of this version, e.g. “v1”, “v2beta1”, etc. Composite resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.
+                      description: Name of this version, e.g. “v1”, “v2beta1”, etc.
+                        Composite resources are served under this version at `/apis/<group>/<version>/...`
+                        if `served` is true.
                       type: string
                     referenceable:
-                      description: Referenceable specifies that this version may be referenced by a Composition in order to configure which resources an XR may be composed of. Exactly one version must be marked as referenceable; all Compositions must target only the referenceable version. The referenceable version must be served.
+                      description: Referenceable specifies that this version may be
+                        referenced by a Composition in order to configure which resources
+                        an XR may be composed of. Exactly one version must be marked
+                        as referenceable; all Compositions must target only the referenceable
+                        version. The referenceable version must be served.
                       type: boolean
                     schema:
-                      description: Schema describes the schema used for validation, pruning, and defaulting of this version of the defined composite resource. Fields required by all composite resources will be injected into this schema automatically, and will override equivalently named fields in this schema. Omitting this schema results in a schema that contains only the fields required by all composite resources.
+                      description: Schema describes the schema used for validation,
+                        pruning, and defaulting of this version of the defined composite
+                        resource. Fields required by all composite resources will
+                        be injected into this schema automatically, and will override
+                        equivalently named fields in this schema. Omitting this schema
+                        results in a schema that contains only the fields required
+                        by all composite resources.
                       properties:
                         openAPIV3Schema:
-                          description: OpenAPIV3Schema is the OpenAPI v3 schema to use for validation and pruning.
+                          description: OpenAPIV3Schema is the OpenAPI v3 schema to
+                            use for validation and pruning.
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                       type: object
                     served:
-                      description: Served specifies that this version should be served via REST APIs.
+                      description: Served specifies that this version should be served
+                        via REST APIs.
                       type: boolean
                   required:
                   - name
@@ -434,7 +634,8 @@ spec:
             - versions
             type: object
           status:
-            description: CompositeResourceDefinitionStatus shows the observed state of the definition.
+            description: CompositeResourceDefinitionStatus shows the observed state
+              of the definition.
             properties:
               conditions:
                 description: Conditions of the resource.
@@ -442,20 +643,25 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
                       type: string
                     reason:
-                      description: A Reason for this condition's last transition from one status to another.
+                      description: A Reason for this condition's last transition from
+                        one status to another.
                       type: string
                     status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -465,10 +671,16 @@ spec:
                   type: object
                 type: array
               controllers:
-                description: Controllers represents the status of the controllers that power this composite resource definition.
+                description: Controllers represents the status of the controllers
+                  that power this composite resource definition.
                 properties:
                   compositeResourceClaimType:
-                    description: The CompositeResourceClaimTypeRef is the type of composite resource claim that Crossplane is currently reconciling for this definition. Its version will eventually become consistent with the definition's referenceable version. Note that clients may interact with any served type; this is simply the type that Crossplane interacts with.
+                    description: The CompositeResourceClaimTypeRef is the type of
+                      composite resource claim that Crossplane is currently reconciling
+                      for this definition. Its version will eventually become consistent
+                      with the definition's referenceable version. Note that clients
+                      may interact with any served type; this is simply the type that
+                      Crossplane interacts with.
                     properties:
                       apiVersion:
                         description: APIVersion of the type.
@@ -481,7 +693,12 @@ spec:
                     - kind
                     type: object
                   compositeResourceType:
-                    description: The CompositeResourceTypeRef is the type of composite resource that Crossplane is currently reconciling for this definition. Its version will eventually become consistent with the definition's referenceable version. Note that clients may interact with any served type; this is simply the type that Crossplane interacts with.
+                    description: The CompositeResourceTypeRef is the type of composite
+                      resource that Crossplane is currently reconciling for this definition.
+                      Its version will eventually become consistent with the definition's
+                      referenceable version. Note that clients may interact with any
+                      served type; this is simply the type that Crossplane interacts
+                      with.
                     properties:
                       apiVersion:
                         description: APIVersion of the type.

--- a/config/crd/bases/apiextensions.ibm.crossplane.io_compositionrevisions.yaml
+++ b/config/crd/bases/apiextensions.ibm.crossplane.io_compositionrevisions.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/config/crd/bases/apiextensions.ibm.crossplane.io_compositionrevisions.yaml
+++ b/config/crd/bases/apiextensions.ibm.crossplane.io_compositionrevisions.yaml
@@ -1,0 +1,588 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: compositionrevisions.apiextensions.ibm.crossplane.io
+spec:
+  group: apiextensions.ibm.crossplane.io
+  names:
+    categories:
+    - crossplane
+    kind: CompositionRevision
+    listKind: CompositionRevisionList
+    plural: compositionrevisions
+    singular: compositionrevision
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.revision
+      name: REVISION
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Current')].status
+      name: CURRENT
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: A CompositionRevision represents a revision in time of a Composition.
+          Revisions are created by Crossplane; they should be treated as immutable.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CompositionRevisionSpec specifies the desired state of the
+              composition revision.
+            properties:
+              compositeTypeRef:
+                description: CompositeTypeRef specifies the type of composite resource
+                  that this composition is compatible with.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the type.
+                    type: string
+                  kind:
+                    description: Kind of the type.
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                type: object
+              patchSets:
+                description: PatchSets define a named set of patches that may be included
+                  by any resource in this Composition. PatchSets cannot themselves
+                  refer to other PatchSets.
+                items:
+                  description: A PatchSet is a set of patches that can be reused from
+                    all resources within a Composition.
+                  properties:
+                    name:
+                      description: Name of this PatchSet.
+                      type: string
+                    patches:
+                      description: Patches will be applied as an overlay to the base
+                        resource.
+                      items:
+                        description: Patch objects are applied between composite and
+                          composed resources. Their behaviour depends on the Type
+                          selected. The default Type, FromCompositeFieldPath, copies
+                          a value from the composite resource to the composed resource,
+                          applying any defined transformers.
+                        properties:
+                          combine:
+                            description: Combine is the patch configuration for a
+                              CombineFromComposite or CombineToComposite patch.
+                            properties:
+                              strategy:
+                                description: Strategy defines the strategy to use
+                                  to combine the input variable values. Currently
+                                  only string is supported.
+                                enum:
+                                - string
+                                type: string
+                              string:
+                                description: String declares that input variables
+                                  should be combined into a single string, using the
+                                  relevant settings for formatting purposes.
+                                properties:
+                                  fmt:
+                                    description: Format the input using a Go format
+                                      string. See https://golang.org/pkg/fmt/ for
+                                      details.
+                                    type: string
+                                required:
+                                - fmt
+                                type: object
+                              variables:
+                                description: Variables are the list of variables whose
+                                  values will be retrieved and combined.
+                                items:
+                                  description: A CombineVariable defines the source
+                                    of a value that is combined with others to form
+                                    and patch an output value. Currently, this only
+                                    supports retrieving values from a field path.
+                                  properties:
+                                    fromFieldPath:
+                                      description: FromFieldPath is the path of the
+                                        field on the source whose value is to be used
+                                        as input.
+                                      type: string
+                                  required:
+                                  - fromFieldPath
+                                  type: object
+                                minItems: 1
+                                type: array
+                            required:
+                            - strategy
+                            - variables
+                            type: object
+                          fromFieldPath:
+                            description: FromFieldPath is the path of the field on
+                              the resource whose value is to be used as input. Required
+                              when type is FromCompositeFieldPath or ToCompositeFieldPath.
+                            type: string
+                          patchSetName:
+                            description: PatchSetName to include patches from. Required
+                              when type is PatchSet.
+                            type: string
+                          policy:
+                            description: Policy configures the specifics of patching
+                              behaviour.
+                            properties:
+                              fromFieldPath:
+                                description: FromFieldPath specifies how to patch
+                                  from a field path. The default is 'Optional', which
+                                  means the patch will be a no-op if the specified
+                                  fromFieldPath does not exist. Use 'Required' if
+                                  the patch should fail if the specified path does
+                                  not exist.
+                                enum:
+                                - Optional
+                                - Required
+                                type: string
+                            type: object
+                          toFieldPath:
+                            description: ToFieldPath is the path of the field on the
+                              resource whose value will be changed with the result
+                              of transforms. Leave empty if you'd like to propagate
+                              to the same path as fromFieldPath.
+                            type: string
+                          transforms:
+                            description: Transforms are the list of functions that
+                              are used as a FIFO pipe for the input to be transformed.
+                            items:
+                              description: Transform is a unit of process whose input
+                                is transformed into an output with the supplied configuration.
+                              properties:
+                                convert:
+                                  description: Convert is used to cast the input into
+                                    the given output type.
+                                  properties:
+                                    toType:
+                                      description: ToType is the type of the output
+                                        of this transform.
+                                      enum:
+                                      - string
+                                      - int
+                                      - int64
+                                      - bool
+                                      - float64
+                                      type: string
+                                  required:
+                                  - toType
+                                  type: object
+                                map:
+                                  additionalProperties:
+                                    type: string
+                                  description: Map uses the input as a key in the
+                                    given map and returns the value.
+                                  type: object
+                                math:
+                                  description: Math is used to transform the input
+                                    via mathematical operations such as multiplication.
+                                  properties:
+                                    multiply:
+                                      description: Multiply the value.
+                                      format: int64
+                                      type: integer
+                                  type: object
+                                string:
+                                  description: String is used to transform the input
+                                    into a string or a different kind of string. Note
+                                    that the input does not necessarily need to be
+                                    a string.
+                                  properties:
+                                    fmt:
+                                      description: Format the input using a Go format
+                                        string. See https://golang.org/pkg/fmt/ for
+                                        details.
+                                      type: string
+                                  required:
+                                  - fmt
+                                  type: object
+                                type:
+                                  description: Type of the transform to be run.
+                                  enum:
+                                  - map
+                                  - math
+                                  - string
+                                  - convert
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            type: array
+                          type:
+                            default: FromCompositeFieldPath
+                            description: Type sets the patching behaviour to be used.
+                              Each patch type may require its' own fields to be set
+                              on the Patch object.
+                            enum:
+                            - FromCompositeFieldPath
+                            - PatchSet
+                            - ToCompositeFieldPath
+                            - CombineFromComposite
+                            - CombineToComposite
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  - patches
+                  type: object
+                type: array
+              resources:
+                description: Resources is the list of resource templates that will
+                  be used when a composite resource referring to this composition
+                  is created.
+                items:
+                  description: ComposedTemplate is used to provide information about
+                    how the composed resource should be processed.
+                  properties:
+                    base:
+                      description: Base is the target resource that the patches will
+                        be applied on.
+                      type: object
+                      x-kubernetes-embedded-resource: true
+                      x-kubernetes-preserve-unknown-fields: true
+                    connectionDetails:
+                      description: ConnectionDetails lists the propagation secret
+                        keys from this target resource to the composition instance
+                        connection secret.
+                      items:
+                        description: ConnectionDetail includes the information about
+                          the propagation of the connection information from one secret
+                          to another.
+                        properties:
+                          fromConnectionSecretKey:
+                            description: FromConnectionSecretKey is the key that will
+                              be used to fetch the value from the given target resource's
+                              secret.
+                            type: string
+                          fromFieldPath:
+                            description: FromFieldPath is the path of the field on
+                              the composed resource whose value to be used as input.
+                              Name must be specified if the type is FromFieldPath
+                              is specified.
+                            type: string
+                          name:
+                            description: Name of the connection secret key that will
+                              be propagated to the connection secret of the composition
+                              instance. Leave empty if you'd like to use the same
+                              key name.
+                            type: string
+                          type:
+                            description: Type sets the connection detail fetching
+                              behaviour to be used. Each connection detail type may
+                              require its own fields to be set on the ConnectionDetail
+                              object. If the type is omitted Crossplane will attempt
+                              to infer it based on which other fields were specified.
+                            enum:
+                            - FromConnectionSecretKey
+                            - FromFieldPath
+                            - FromValue
+                            type: string
+                          value:
+                            description: Value that will be propagated to the connection
+                              secret of the composition instance. Typically you should
+                              use FromConnectionSecretKey instead, but an explicit
+                              value may be set to inject a fixed, non-sensitive connection
+                              secret values, for example a well-known port. Supercedes
+                              FromConnectionSecretKey when set.
+                            type: string
+                        type: object
+                      type: array
+                    name:
+                      description: A Name uniquely identifies this entry within its
+                        Composition's resources array. Names are optional but *strongly*
+                        recommended. When all entries in the resources array are named
+                        entries may added, deleted, and reordered as long as their
+                        names do not change. When entries are not named the length
+                        and order of the resources array should be treated as immutable.
+                        Either all or no entries must be named.
+                      type: string
+                    patches:
+                      description: Patches will be applied as overlay to the base
+                        resource.
+                      items:
+                        description: Patch objects are applied between composite and
+                          composed resources. Their behaviour depends on the Type
+                          selected. The default Type, FromCompositeFieldPath, copies
+                          a value from the composite resource to the composed resource,
+                          applying any defined transformers.
+                        properties:
+                          combine:
+                            description: Combine is the patch configuration for a
+                              CombineFromComposite or CombineToComposite patch.
+                            properties:
+                              strategy:
+                                description: Strategy defines the strategy to use
+                                  to combine the input variable values. Currently
+                                  only string is supported.
+                                enum:
+                                - string
+                                type: string
+                              string:
+                                description: String declares that input variables
+                                  should be combined into a single string, using the
+                                  relevant settings for formatting purposes.
+                                properties:
+                                  fmt:
+                                    description: Format the input using a Go format
+                                      string. See https://golang.org/pkg/fmt/ for
+                                      details.
+                                    type: string
+                                required:
+                                - fmt
+                                type: object
+                              variables:
+                                description: Variables are the list of variables whose
+                                  values will be retrieved and combined.
+                                items:
+                                  description: A CombineVariable defines the source
+                                    of a value that is combined with others to form
+                                    and patch an output value. Currently, this only
+                                    supports retrieving values from a field path.
+                                  properties:
+                                    fromFieldPath:
+                                      description: FromFieldPath is the path of the
+                                        field on the source whose value is to be used
+                                        as input.
+                                      type: string
+                                  required:
+                                  - fromFieldPath
+                                  type: object
+                                minItems: 1
+                                type: array
+                            required:
+                            - strategy
+                            - variables
+                            type: object
+                          fromFieldPath:
+                            description: FromFieldPath is the path of the field on
+                              the resource whose value is to be used as input. Required
+                              when type is FromCompositeFieldPath or ToCompositeFieldPath.
+                            type: string
+                          patchSetName:
+                            description: PatchSetName to include patches from. Required
+                              when type is PatchSet.
+                            type: string
+                          policy:
+                            description: Policy configures the specifics of patching
+                              behaviour.
+                            properties:
+                              fromFieldPath:
+                                description: FromFieldPath specifies how to patch
+                                  from a field path. The default is 'Optional', which
+                                  means the patch will be a no-op if the specified
+                                  fromFieldPath does not exist. Use 'Required' if
+                                  the patch should fail if the specified path does
+                                  not exist.
+                                enum:
+                                - Optional
+                                - Required
+                                type: string
+                            type: object
+                          toFieldPath:
+                            description: ToFieldPath is the path of the field on the
+                              resource whose value will be changed with the result
+                              of transforms. Leave empty if you'd like to propagate
+                              to the same path as fromFieldPath.
+                            type: string
+                          transforms:
+                            description: Transforms are the list of functions that
+                              are used as a FIFO pipe for the input to be transformed.
+                            items:
+                              description: Transform is a unit of process whose input
+                                is transformed into an output with the supplied configuration.
+                              properties:
+                                convert:
+                                  description: Convert is used to cast the input into
+                                    the given output type.
+                                  properties:
+                                    toType:
+                                      description: ToType is the type of the output
+                                        of this transform.
+                                      enum:
+                                      - string
+                                      - int
+                                      - int64
+                                      - bool
+                                      - float64
+                                      type: string
+                                  required:
+                                  - toType
+                                  type: object
+                                map:
+                                  additionalProperties:
+                                    type: string
+                                  description: Map uses the input as a key in the
+                                    given map and returns the value.
+                                  type: object
+                                math:
+                                  description: Math is used to transform the input
+                                    via mathematical operations such as multiplication.
+                                  properties:
+                                    multiply:
+                                      description: Multiply the value.
+                                      format: int64
+                                      type: integer
+                                  type: object
+                                string:
+                                  description: String is used to transform the input
+                                    into a string or a different kind of string. Note
+                                    that the input does not necessarily need to be
+                                    a string.
+                                  properties:
+                                    fmt:
+                                      description: Format the input using a Go format
+                                        string. See https://golang.org/pkg/fmt/ for
+                                        details.
+                                      type: string
+                                  required:
+                                  - fmt
+                                  type: object
+                                type:
+                                  description: Type of the transform to be run.
+                                  enum:
+                                  - map
+                                  - math
+                                  - string
+                                  - convert
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            type: array
+                          type:
+                            default: FromCompositeFieldPath
+                            description: Type sets the patching behaviour to be used.
+                              Each patch type may require its' own fields to be set
+                              on the Patch object.
+                            enum:
+                            - FromCompositeFieldPath
+                            - PatchSet
+                            - ToCompositeFieldPath
+                            - CombineFromComposite
+                            - CombineToComposite
+                            type: string
+                        type: object
+                      type: array
+                    readinessChecks:
+                      description: ReadinessChecks allows users to define custom readiness
+                        checks. All checks have to return true in order for resource
+                        to be considered ready. The default readiness check is to
+                        have the "Ready" condition to be "True".
+                      items:
+                        description: ReadinessCheck is used to indicate how to tell
+                          whether a resource is ready for consumption
+                        properties:
+                          fieldPath:
+                            description: FieldPath shows the path of the field whose
+                              value will be used.
+                            type: string
+                          matchInteger:
+                            description: MatchInt is the value you'd like to match
+                              if you're using "MatchInt" type.
+                            format: int64
+                            type: integer
+                          matchString:
+                            description: MatchString is the value you'd like to match
+                              if you're using "MatchString" type.
+                            type: string
+                          type:
+                            description: Type indicates the type of probe you'd like
+                              to use.
+                            enum:
+                            - MatchString
+                            - MatchInteger
+                            - NonEmpty
+                            - None
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      type: array
+                  required:
+                  - base
+                  type: object
+                type: array
+              revision:
+                description: Revision number. Newer revisions have larger numbers.
+                format: int64
+                type: integer
+              writeConnectionSecretsToNamespace:
+                description: WriteConnectionSecretsToNamespace specifies the namespace
+                  in which the connection secrets of composite resource dynamically
+                  provisioned using this composition will be created.
+                type: string
+            required:
+            - compositeTypeRef
+            - resources
+            - revision
+            type: object
+          status:
+            description: CompositionRevisionStatus shows the observed state of the
+              composition revision.
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from
+                        one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
+                      type: string
+                    type:
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/apiextensions.ibm.crossplane.io_compositions.yaml
+++ b/config/crd/bases/apiextensions.ibm.crossplane.io_compositions.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/config/crd/bases/apiextensions.ibm.crossplane.io_compositions.yaml
+++ b/config/crd/bases/apiextensions.ibm.crossplane.io_compositions.yaml
@@ -25,21 +25,26 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: Composition defines the group of resources to be created when a compatible type is created with reference to the composition.
+        description: A Composition specifies how a composite resource should be composed.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: CompositionSpec specifies the desired state of the definition.
+            description: CompositionSpec specifies desired state of a composition.
             properties:
               compositeTypeRef:
-                description: CompositeTypeRef specifies the type of composite resource that this composition is compatible with.
+                description: CompositeTypeRef specifies the type of composite resource
+                  that this composition is compatible with.
                 properties:
                   apiVersion:
                     description: APIVersion of the type.
@@ -52,50 +57,135 @@ spec:
                 - kind
                 type: object
               patchSets:
-                description: PatchSets define a named set of patches that may be included by any resource in this Composition. PatchSets cannot themselves refer to other PatchSets.
+                description: PatchSets define a named set of patches that may be included
+                  by any resource in this Composition. PatchSets cannot themselves
+                  refer to other PatchSets.
                 items:
-                  description: A PatchSet is a set of patches that can be reused from all resources within a Composition.
+                  description: A PatchSet is a set of patches that can be reused from
+                    all resources within a Composition.
                   properties:
                     name:
                       description: Name of this PatchSet.
                       type: string
                     patches:
-                      description: Patches will be applied as an overlay to the base resource.
+                      description: Patches will be applied as an overlay to the base
+                        resource.
                       items:
-                        description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
+                        description: Patch objects are applied between composite and
+                          composed resources. Their behaviour depends on the Type
+                          selected. The default Type, FromCompositeFieldPath, copies
+                          a value from the composite resource to the composed resource,
+                          applying any defined transformers.
                         properties:
+                          combine:
+                            description: Combine is the patch configuration for a
+                              CombineFromComposite or CombineToComposite patch.
+                            properties:
+                              strategy:
+                                description: Strategy defines the strategy to use
+                                  to combine the input variable values. Currently
+                                  only string is supported.
+                                enum:
+                                - string
+                                type: string
+                              string:
+                                description: String declares that input variables
+                                  should be combined into a single string, using the
+                                  relevant settings for formatting purposes.
+                                properties:
+                                  fmt:
+                                    description: Format the input using a Go format
+                                      string. See https://golang.org/pkg/fmt/ for
+                                      details.
+                                    type: string
+                                required:
+                                - fmt
+                                type: object
+                              variables:
+                                description: Variables are the list of variables whose
+                                  values will be retrieved and combined.
+                                items:
+                                  description: A CombineVariable defines the source
+                                    of a value that is combined with others to form
+                                    and patch an output value. Currently, this only
+                                    supports retrieving values from a field path.
+                                  properties:
+                                    fromFieldPath:
+                                      description: FromFieldPath is the path of the
+                                        field on the source whose value is to be used
+                                        as input.
+                                      type: string
+                                  required:
+                                  - fromFieldPath
+                                  type: object
+                                minItems: 1
+                                type: array
+                            required:
+                            - strategy
+                            - variables
+                            type: object
                           fromFieldPath:
-                            description: FromFieldPath is the path of the field on the resource whose value is to be used as input. Required when type is FromCompositeFieldPath or ToCompositeFieldPath.
+                            description: FromFieldPath is the path of the field on
+                              the resource whose value is to be used as input. Required
+                              when type is FromCompositeFieldPath or ToCompositeFieldPath.
                             type: string
                           patchSetName:
-                            description: PatchSetName to include patches from. Required when type is PatchSet.
+                            description: PatchSetName to include patches from. Required
+                              when type is PatchSet.
                             type: string
                           policy:
-                            description: Policy configures the specifics of patching behaviour.
+                            description: Policy configures the specifics of patching
+                              behaviour.
                             properties:
                               fromFieldPath:
-                                description: FromFieldPath specifies how to patch from a field path. The default is 'Optional', which means the patch will be a no-op if the specified fromFieldPath does not exist. Use 'Required' if the patch should fail if the specified path does not exist.
+                                description: FromFieldPath specifies how to patch
+                                  from a field path. The default is 'Optional', which
+                                  means the patch will be a no-op if the specified
+                                  fromFieldPath does not exist. Use 'Required' if
+                                  the patch should fail if the specified path does
+                                  not exist.
                                 enum:
                                 - Optional
                                 - Required
                                 type: string
+                              mergeOptions:
+                                description: MergeOptions Specifies merge options
+                                  on a field path
+                                properties:
+                                  appendSlice:
+                                    description: Specifies that already existing elements
+                                      in a merged slice should be preserved
+                                    type: boolean
+                                  keepMapValues:
+                                    description: Specifies that already existing values
+                                      in a merged map should be preserved
+                                    type: boolean
+                                type: object
                             type: object
                           toFieldPath:
-                            description: ToFieldPath is the path of the field on the resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path as fromFieldPath.
+                            description: ToFieldPath is the path of the field on the
+                              resource whose value will be changed with the result
+                              of transforms. Leave empty if you'd like to propagate
+                              to the same path as fromFieldPath.
                             type: string
                           transforms:
-                            description: Transforms are the list of functions that are used as a FIFO pipe for the input to be transformed.
+                            description: Transforms are the list of functions that
+                              are used as a FIFO pipe for the input to be transformed.
                             items:
-                              description: Transform is a unit of process whose input is transformed into an output with the supplied configuration.
+                              description: Transform is a unit of process whose input
+                                is transformed into an output with the supplied configuration.
                               properties:
                                 convert:
-                                  description: Convert is used to cast the input into the given output type.
+                                  description: Convert is used to cast the input into
+                                    the given output type.
                                   properties:
                                     toType:
-                                      description: ToType is the type of the output of this transform.
+                                      description: ToType is the type of the output
+                                        of this transform.
                                       enum:
                                       - string
                                       - int
+                                      - int64
                                       - bool
                                       - float64
                                       type: string
@@ -105,10 +195,12 @@ spec:
                                 map:
                                   additionalProperties:
                                     type: string
-                                  description: Map uses the input as a key in the given map and returns the value.
+                                  description: Map uses the input as a key in the
+                                    given map and returns the value.
                                   type: object
                                 math:
-                                  description: Math is used to transform the input via mathematical operations such as multiplication.
+                                  description: Math is used to transform the input
+                                    via mathematical operations such as multiplication.
                                   properties:
                                     multiply:
                                       description: Multiply the value.
@@ -116,10 +208,15 @@ spec:
                                       type: integer
                                   type: object
                                 string:
-                                  description: String is used to transform the input into a string or a different kind of string. Note that the input does not necessarily need to be a string.
+                                  description: String is used to transform the input
+                                    into a string or a different kind of string. Note
+                                    that the input does not necessarily need to be
+                                    a string.
                                   properties:
                                     fmt:
-                                      description: Format the input using a Go format string. See https://golang.org/pkg/fmt/ for details.
+                                      description: Format the input using a Go format
+                                        string. See https://golang.org/pkg/fmt/ for
+                                        details.
                                       type: string
                                   required:
                                   - fmt
@@ -138,11 +235,15 @@ spec:
                             type: array
                           type:
                             default: FromCompositeFieldPath
-                            description: Type sets the patching behaviour to be used. Each patch type may require its' own fields to be set on the Patch object.
+                            description: Type sets the patching behaviour to be used.
+                              Each patch type may require its' own fields to be set
+                              on the Patch object.
                             enum:
                             - FromCompositeFieldPath
                             - PatchSet
                             - ToCompositeFieldPath
+                            - CombineFromComposite
+                            - CombineToComposite
                             type: string
                         type: object
                       type: array
@@ -152,81 +253,194 @@ spec:
                   type: object
                 type: array
               resources:
-                description: Resources is the list of resource templates that will be used when a composite resource referring to this composition is created.
+                description: Resources is the list of resource templates that will
+                  be used when a composite resource referring to this composition
+                  is created.
                 items:
-                  description: ComposedTemplate is used to provide information about how the composed resource should be processed.
+                  description: ComposedTemplate is used to provide information about
+                    how the composed resource should be processed.
                   properties:
                     base:
-                      description: Base is the target resource that the patches will be applied on.
+                      description: Base is the target resource that the patches will
+                        be applied on.
                       type: object
                       x-kubernetes-embedded-resource: true
                       x-kubernetes-preserve-unknown-fields: true
                     connectionDetails:
-                      description: ConnectionDetails lists the propagation secret keys from this target resource to the composition instance connection secret.
+                      description: ConnectionDetails lists the propagation secret
+                        keys from this target resource to the composition instance
+                        connection secret.
                       items:
-                        description: ConnectionDetail includes the information about the propagation of the connection information from one secret to another.
+                        description: ConnectionDetail includes the information about
+                          the propagation of the connection information from one secret
+                          to another.
                         properties:
                           fromConnectionSecretKey:
-                            description: FromConnectionSecretKey is the key that will be used to fetch the value from the given target resource's secret.
+                            description: FromConnectionSecretKey is the key that will
+                              be used to fetch the value from the given target resource's
+                              secret.
                             type: string
                           fromFieldPath:
-                            description: FromFieldPath is the path of the field on the composed resource whose value to be used as input. Name must be specified if the type is FromFieldPath is specified.
+                            description: FromFieldPath is the path of the field on
+                              the composed resource whose value to be used as input.
+                              Name must be specified if the type is FromFieldPath
+                              is specified.
                             type: string
                           name:
-                            description: Name of the connection secret key that will be propagated to the connection secret of the composition instance. Leave empty if you'd like to use the same key name.
+                            description: Name of the connection secret key that will
+                              be propagated to the connection secret of the composition
+                              instance. Leave empty if you'd like to use the same
+                              key name.
                             type: string
                           type:
-                            description: Type sets the connection detail fetching behaviour to be used. Each connection detail type may require its own fields to be set on the ConnectionDetail object. If the type is omitted Crossplane will attempt to infer it based on which other fields were specified.
+                            description: Type sets the connection detail fetching
+                              behaviour to be used. Each connection detail type may
+                              require its own fields to be set on the ConnectionDetail
+                              object. If the type is omitted Crossplane will attempt
+                              to infer it based on which other fields were specified.
                             enum:
                             - FromConnectionSecretKey
                             - FromFieldPath
                             - FromValue
                             type: string
                           value:
-                            description: Value that will be propagated to the connection secret of the composition instance. Typically you should use FromConnectionSecretKey instead, but an explicit value may be set to inject a fixed, non-sensitive connection secret values, for example a well-known port. Supercedes FromConnectionSecretKey when set.
+                            description: Value that will be propagated to the connection
+                              secret of the composition instance. Typically you should
+                              use FromConnectionSecretKey instead, but an explicit
+                              value may be set to inject a fixed, non-sensitive connection
+                              secret values, for example a well-known port. Supercedes
+                              FromConnectionSecretKey when set.
                             type: string
                         type: object
                       type: array
                     name:
-                      description: A Name uniquely identifies this entry within its Composition's resources array. Names are optional but *strongly* recommended. When all entries in the resources array are named entries may added, deleted, and reordered as long as their names do not change. When entries are not named the length and order of the resources array should be treated as immutable. Either all or no entries must be named.
+                      description: A Name uniquely identifies this entry within its
+                        Composition's resources array. Names are optional but *strongly*
+                        recommended. When all entries in the resources array are named
+                        entries may added, deleted, and reordered as long as their
+                        names do not change. When entries are not named the length
+                        and order of the resources array should be treated as immutable.
+                        Either all or no entries must be named.
                       type: string
                     patches:
-                      description: Patches will be applied as overlay to the base resource.
+                      description: Patches will be applied as overlay to the base
+                        resource.
                       items:
-                        description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
+                        description: Patch objects are applied between composite and
+                          composed resources. Their behaviour depends on the Type
+                          selected. The default Type, FromCompositeFieldPath, copies
+                          a value from the composite resource to the composed resource,
+                          applying any defined transformers.
                         properties:
+                          combine:
+                            description: Combine is the patch configuration for a
+                              CombineFromComposite or CombineToComposite patch.
+                            properties:
+                              strategy:
+                                description: Strategy defines the strategy to use
+                                  to combine the input variable values. Currently
+                                  only string is supported.
+                                enum:
+                                - string
+                                type: string
+                              string:
+                                description: String declares that input variables
+                                  should be combined into a single string, using the
+                                  relevant settings for formatting purposes.
+                                properties:
+                                  fmt:
+                                    description: Format the input using a Go format
+                                      string. See https://golang.org/pkg/fmt/ for
+                                      details.
+                                    type: string
+                                required:
+                                - fmt
+                                type: object
+                              variables:
+                                description: Variables are the list of variables whose
+                                  values will be retrieved and combined.
+                                items:
+                                  description: A CombineVariable defines the source
+                                    of a value that is combined with others to form
+                                    and patch an output value. Currently, this only
+                                    supports retrieving values from a field path.
+                                  properties:
+                                    fromFieldPath:
+                                      description: FromFieldPath is the path of the
+                                        field on the source whose value is to be used
+                                        as input.
+                                      type: string
+                                  required:
+                                  - fromFieldPath
+                                  type: object
+                                minItems: 1
+                                type: array
+                            required:
+                            - strategy
+                            - variables
+                            type: object
                           fromFieldPath:
-                            description: FromFieldPath is the path of the field on the resource whose value is to be used as input. Required when type is FromCompositeFieldPath or ToCompositeFieldPath.
+                            description: FromFieldPath is the path of the field on
+                              the resource whose value is to be used as input. Required
+                              when type is FromCompositeFieldPath or ToCompositeFieldPath.
                             type: string
                           patchSetName:
-                            description: PatchSetName to include patches from. Required when type is PatchSet.
+                            description: PatchSetName to include patches from. Required
+                              when type is PatchSet.
                             type: string
                           policy:
-                            description: Policy configures the specifics of patching behaviour.
+                            description: Policy configures the specifics of patching
+                              behaviour.
                             properties:
                               fromFieldPath:
-                                description: FromFieldPath specifies how to patch from a field path. The default is 'Optional', which means the patch will be a no-op if the specified fromFieldPath does not exist. Use 'Required' if the patch should fail if the specified path does not exist.
+                                description: FromFieldPath specifies how to patch
+                                  from a field path. The default is 'Optional', which
+                                  means the patch will be a no-op if the specified
+                                  fromFieldPath does not exist. Use 'Required' if
+                                  the patch should fail if the specified path does
+                                  not exist.
                                 enum:
                                 - Optional
                                 - Required
                                 type: string
+                              mergeOptions:
+                                description: MergeOptions Specifies merge options
+                                  on a field path
+                                properties:
+                                  appendSlice:
+                                    description: Specifies that already existing elements
+                                      in a merged slice should be preserved
+                                    type: boolean
+                                  keepMapValues:
+                                    description: Specifies that already existing values
+                                      in a merged map should be preserved
+                                    type: boolean
+                                type: object
                             type: object
                           toFieldPath:
-                            description: ToFieldPath is the path of the field on the resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path as fromFieldPath.
+                            description: ToFieldPath is the path of the field on the
+                              resource whose value will be changed with the result
+                              of transforms. Leave empty if you'd like to propagate
+                              to the same path as fromFieldPath.
                             type: string
                           transforms:
-                            description: Transforms are the list of functions that are used as a FIFO pipe for the input to be transformed.
+                            description: Transforms are the list of functions that
+                              are used as a FIFO pipe for the input to be transformed.
                             items:
-                              description: Transform is a unit of process whose input is transformed into an output with the supplied configuration.
+                              description: Transform is a unit of process whose input
+                                is transformed into an output with the supplied configuration.
                               properties:
                                 convert:
-                                  description: Convert is used to cast the input into the given output type.
+                                  description: Convert is used to cast the input into
+                                    the given output type.
                                   properties:
                                     toType:
-                                      description: ToType is the type of the output of this transform.
+                                      description: ToType is the type of the output
+                                        of this transform.
                                       enum:
                                       - string
                                       - int
+                                      - int64
                                       - bool
                                       - float64
                                       type: string
@@ -236,10 +450,12 @@ spec:
                                 map:
                                   additionalProperties:
                                     type: string
-                                  description: Map uses the input as a key in the given map and returns the value.
+                                  description: Map uses the input as a key in the
+                                    given map and returns the value.
                                   type: object
                                 math:
-                                  description: Math is used to transform the input via mathematical operations such as multiplication.
+                                  description: Math is used to transform the input
+                                    via mathematical operations such as multiplication.
                                   properties:
                                     multiply:
                                       description: Multiply the value.
@@ -247,10 +463,15 @@ spec:
                                       type: integer
                                   type: object
                                 string:
-                                  description: String is used to transform the input into a string or a different kind of string. Note that the input does not necessarily need to be a string.
+                                  description: String is used to transform the input
+                                    into a string or a different kind of string. Note
+                                    that the input does not necessarily need to be
+                                    a string.
                                   properties:
                                     fmt:
-                                      description: Format the input using a Go format string. See https://golang.org/pkg/fmt/ for details.
+                                      description: Format the input using a Go format
+                                        string. See https://golang.org/pkg/fmt/ for
+                                        details.
                                       type: string
                                   required:
                                   - fmt
@@ -269,31 +490,43 @@ spec:
                             type: array
                           type:
                             default: FromCompositeFieldPath
-                            description: Type sets the patching behaviour to be used. Each patch type may require its' own fields to be set on the Patch object.
+                            description: Type sets the patching behaviour to be used.
+                              Each patch type may require its' own fields to be set
+                              on the Patch object.
                             enum:
                             - FromCompositeFieldPath
                             - PatchSet
                             - ToCompositeFieldPath
+                            - CombineFromComposite
+                            - CombineToComposite
                             type: string
                         type: object
                       type: array
                     readinessChecks:
-                      description: ReadinessChecks allows users to define custom readiness checks. All checks have to return true in order for resource to be considered ready. The default readiness check is to have the "Ready" condition to be "True".
+                      description: ReadinessChecks allows users to define custom readiness
+                        checks. All checks have to return true in order for resource
+                        to be considered ready. The default readiness check is to
+                        have the "Ready" condition to be "True".
                       items:
-                        description: ReadinessCheck is used to indicate how to tell whether a resource is ready for consumption
+                        description: ReadinessCheck is used to indicate how to tell
+                          whether a resource is ready for consumption
                         properties:
                           fieldPath:
-                            description: FieldPath shows the path of the field whose value will be used.
+                            description: FieldPath shows the path of the field whose
+                              value will be used.
                             type: string
                           matchInteger:
-                            description: MatchInt is the value you'd like to match if you're using "MatchInt" type.
+                            description: MatchInt is the value you'd like to match
+                              if you're using "MatchInt" type.
                             format: int64
                             type: integer
                           matchString:
-                            description: MatchString is the value you'd like to match if you're using "MatchString" type.
+                            description: MatchString is the value you'd like to match
+                              if you're using "MatchString" type.
                             type: string
                           type:
-                            description: Type indicates the type of probe you'd like to use.
+                            description: Type indicates the type of probe you'd like
+                              to use.
                             enum:
                             - MatchString
                             - MatchInteger
@@ -309,49 +542,18 @@ spec:
                   type: object
                 type: array
               writeConnectionSecretsToNamespace:
-                description: WriteConnectionSecretsToNamespace specifies the namespace in which the connection secrets of composite resource dynamically provisioned using this composition will be created.
+                description: WriteConnectionSecretsToNamespace specifies the namespace
+                  in which the connection secrets of composite resource dynamically
+                  provisioned using this composition will be created.
                 type: string
             required:
             - compositeTypeRef
             - resources
             type: object
-          status:
-            description: CompositionStatus shows the observed state of the composition.
-            properties:
-              conditions:
-                description: Conditions of the resource.
-                items:
-                  description: A Condition that may apply to a resource.
-                  properties:
-                    lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
-                      format: date-time
-                      type: string
-                    message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
-                      type: string
-                    reason:
-                      description: A Reason for this condition's last transition from one status to another.
-                      type: string
-                    status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
-                      type: string
-                    type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-            type: object
         type: object
     served: true
     storage: true
-    subresources:
-      status: {}
+    subresources: {}
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
@@ -359,21 +561,29 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Composition defines the group of resources to be created when a compatible type is created with reference to the composition.
+        description: 'Composition defines the group of resources to be created when
+          a compatible type is created with reference to the composition. [DEPRECATED]:
+          Please use the identical v1 API instead. The v1beta1 API is scheduled to
+          be removed in Crossplane v1.6.'
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: CompositionSpec specifies the desired state of the definition.
+            description: CompositionSpec specifies the desired state of the composition.
             properties:
               compositeTypeRef:
-                description: CompositeTypeRef specifies the type of composite resource that this composition is compatible with.
+                description: CompositeTypeRef specifies the type of composite resource
+                  that this composition is compatible with.
                 properties:
                   apiVersion:
                     description: APIVersion of the type.
@@ -386,47 +596,131 @@ spec:
                 - kind
                 type: object
               patchSets:
-                description: PatchSets define a named set of patches that may be included by any resource in this Composition. PatchSets cannot themselves refer to other PatchSets.
+                description: PatchSets define a named set of patches that may be included
+                  by any resource in this Composition. PatchSets cannot themselves
+                  refer to other PatchSets.
                 items:
-                  description: A PatchSet is a set of patches that can be reused from all resources within a Composition.
+                  description: A PatchSet is a set of patches that can be reused from
+                    all resources within a Composition.
                   properties:
                     name:
                       description: Name of this PatchSet.
                       type: string
                     patches:
-                      description: Patches will be applied as an overlay to the base resource.
+                      description: Patches will be applied as an overlay to the base
+                        resource.
                       items:
-                        description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
+                        description: Patch objects are applied between composite and
+                          composed resources. Their behaviour depends on the Type
+                          selected. The default Type, FromCompositeFieldPath, copies
+                          a value from the composite resource to the composed resource,
+                          applying any defined transformers.
                         properties:
+                          combine:
+                            description: Combine is the patch configuration for a
+                              CombineFromComposite or CombineToComposite patch.
+                            properties:
+                              strategy:
+                                description: Strategy defines the strategy to use
+                                  to combine the input variable values. Currently
+                                  only string is supported.
+                                enum:
+                                - string
+                                type: string
+                              string:
+                                description: String declares that input variables
+                                  should be combined into a single string, using the
+                                  relevant settings for formatting purposes.
+                                properties:
+                                  fmt:
+                                    description: Format the input using a Go format
+                                      string. See https://golang.org/pkg/fmt/ for
+                                      details.
+                                    type: string
+                                required:
+                                - fmt
+                                type: object
+                              variables:
+                                description: Variables are the list of variables whose
+                                  values will be retrieved and combined.
+                                items:
+                                  description: A CombineVariable defines the source
+                                    of a value that is combined with others to form
+                                    and patch an output value. Currently, this only
+                                    supports retrieving values from a field path.
+                                  properties:
+                                    fromFieldPath:
+                                      description: FromFieldPath is the path of the
+                                        field on the source whose value is to be used
+                                        as input.
+                                      type: string
+                                  required:
+                                  - fromFieldPath
+                                  type: object
+                                minItems: 1
+                                type: array
+                            required:
+                            - strategy
+                            - variables
+                            type: object
                           fromFieldPath:
-                            description: FromFieldPath is the path of the field on the resource whose value is to be used as input. Required when type is FromCompositeFieldPath or ToCompositeFieldPath.
+                            description: FromFieldPath is the path of the field on
+                              the resource whose value is to be used as input. Required
+                              when type is FromCompositeFieldPath or ToCompositeFieldPath.
                             type: string
                           patchSetName:
-                            description: PatchSetName to include patches from. Required when type is PatchSet.
+                            description: PatchSetName to include patches from. Required
+                              when type is PatchSet.
                             type: string
                           policy:
-                            description: Policy configures the specifics of patching behaviour.
+                            description: Policy configures the specifics of patching
+                              behaviour.
                             properties:
                               fromFieldPath:
-                                description: FromFieldPath specifies how to patch from a field path. The default is 'Optional', which means the patch will be a no-op if the specified fromFieldPath does not exist. Use 'Required' if the patch should fail if the specified path does not exist.
+                                description: FromFieldPath specifies how to patch
+                                  from a field path. The default is 'Optional', which
+                                  means the patch will be a no-op if the specified
+                                  fromFieldPath does not exist. Use 'Required' if
+                                  the patch should fail if the specified path does
+                                  not exist.
                                 enum:
                                 - Optional
                                 - Required
                                 type: string
+                              mergeOptions:
+                                description: MergeOptions Specifies merge options
+                                  on a field path
+                                properties:
+                                  appendSlice:
+                                    description: Specifies that already existing elements
+                                      in a merged slice should be preserved
+                                    type: boolean
+                                  keepMapValues:
+                                    description: Specifies that already existing values
+                                      in a merged map should be preserved
+                                    type: boolean
+                                type: object
                             type: object
                           toFieldPath:
-                            description: ToFieldPath is the path of the field on the resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path as fromFieldPath.
+                            description: ToFieldPath is the path of the field on the
+                              resource whose value will be changed with the result
+                              of transforms. Leave empty if you'd like to propagate
+                              to the same path as fromFieldPath.
                             type: string
                           transforms:
-                            description: Transforms are the list of functions that are used as a FIFO pipe for the input to be transformed.
+                            description: Transforms are the list of functions that
+                              are used as a FIFO pipe for the input to be transformed.
                             items:
-                              description: Transform is a unit of process whose input is transformed into an output with the supplied configuration.
+                              description: Transform is a unit of process whose input
+                                is transformed into an output with the supplied configuration.
                               properties:
                                 convert:
-                                  description: Convert is used to cast the input into the given output type.
+                                  description: Convert is used to cast the input into
+                                    the given output type.
                                   properties:
                                     toType:
-                                      description: ToType is the type of the output of this transform.
+                                      description: ToType is the type of the output
+                                        of this transform.
                                       enum:
                                       - string
                                       - int
@@ -439,10 +733,12 @@ spec:
                                 map:
                                   additionalProperties:
                                     type: string
-                                  description: Map uses the input as a key in the given map and returns the value.
+                                  description: Map uses the input as a key in the
+                                    given map and returns the value.
                                   type: object
                                 math:
-                                  description: Math is used to transform the input via mathematical operations such as multiplication.
+                                  description: Math is used to transform the input
+                                    via mathematical operations such as multiplication.
                                   properties:
                                     multiply:
                                       description: Multiply the value.
@@ -450,10 +746,15 @@ spec:
                                       type: integer
                                   type: object
                                 string:
-                                  description: String is used to transform the input into a string or a different kind of string. Note that the input does not necessarily need to be a string.
+                                  description: String is used to transform the input
+                                    into a string or a different kind of string. Note
+                                    that the input does not necessarily need to be
+                                    a string.
                                   properties:
                                     fmt:
-                                      description: Format the input using a Go format string. See https://golang.org/pkg/fmt/ for details.
+                                      description: Format the input using a Go format
+                                        string. See https://golang.org/pkg/fmt/ for
+                                        details.
                                       type: string
                                   required:
                                   - fmt
@@ -472,11 +773,15 @@ spec:
                             type: array
                           type:
                             default: FromCompositeFieldPath
-                            description: Type sets the patching behaviour to be used. Each patch type may require its' own fields to be set on the Patch object.
+                            description: Type sets the patching behaviour to be used.
+                              Each patch type may require its' own fields to be set
+                              on the Patch object.
                             enum:
                             - FromCompositeFieldPath
                             - PatchSet
                             - ToCompositeFieldPath
+                            - CombineFromComposite
+                            - CombineToComposite
                             type: string
                         type: object
                       type: array
@@ -486,78 +791,190 @@ spec:
                   type: object
                 type: array
               resources:
-                description: Resources is the list of resource templates that will be used when a composite resource referring to this composition is created.
+                description: Resources is the list of resource templates that will
+                  be used when a composite resource referring to this composition
+                  is created.
                 items:
-                  description: ComposedTemplate is used to provide information about how the composed resource should be processed.
+                  description: ComposedTemplate is used to provide information about
+                    how the composed resource should be processed.
                   properties:
                     base:
-                      description: Base is the target resource that the patches will be applied on.
+                      description: Base is the target resource that the patches will
+                        be applied on.
                       type: object
                       x-kubernetes-embedded-resource: true
                       x-kubernetes-preserve-unknown-fields: true
                     connectionDetails:
-                      description: ConnectionDetails lists the propagation secret keys from this target resource to the composition instance connection secret.
+                      description: ConnectionDetails lists the propagation secret
+                        keys from this target resource to the composition instance
+                        connection secret.
                       items:
-                        description: ConnectionDetail includes the information about the propagation of the connection information from one secret to another.
+                        description: ConnectionDetail includes the information about
+                          the propagation of the connection information from one secret
+                          to another.
                         properties:
                           fromConnectionSecretKey:
-                            description: FromConnectionSecretKey is the key that will be used to fetch the value from the given target resource's secret.
+                            description: FromConnectionSecretKey is the key that will
+                              be used to fetch the value from the given target resource's
+                              secret.
                             type: string
                           fromFieldPath:
-                            description: FromFieldPath is the path of the field on the composed resource whose value to be used as input. Name must be specified if the type is FromFieldPath is specified.
+                            description: FromFieldPath is the path of the field on
+                              the composed resource whose value to be used as input.
+                              Name must be specified if the type is FromFieldPath
+                              is specified.
                             type: string
                           name:
-                            description: Name of the connection secret key that will be propagated to the connection secret of the composition instance. Leave empty if you'd like to use the same key name.
+                            description: Name of the connection secret key that will
+                              be propagated to the connection secret of the composition
+                              instance. Leave empty if you'd like to use the same
+                              key name.
                             type: string
                           type:
-                            description: Type sets the connection detail fetching behaviour to be used. Each connection detail type may require its own fields to be set on the ConnectionDetail object. If the type is omitted Crossplane will attempt to infer it based on which other fields were specified.
+                            description: Type sets the connection detail fetching
+                              behaviour to be used. Each connection detail type may
+                              require its own fields to be set on the ConnectionDetail
+                              object. If the type is omitted Crossplane will attempt
+                              to infer it based on which other fields were specified.
                             enum:
                             - FromConnectionSecretKey
                             - FromFieldPath
                             - FromValue
                             type: string
                           value:
-                            description: Value that will be propagated to the connection secret of the composition instance. Typically you should use FromConnectionSecretKey instead, but an explicit value may be set to inject a fixed, non-sensitive connection secret values, for example a well-known port. Supercedes FromConnectionSecretKey when set.
+                            description: Value that will be propagated to the connection
+                              secret of the composition instance. Typically you should
+                              use FromConnectionSecretKey instead, but an explicit
+                              value may be set to inject a fixed, non-sensitive connection
+                              secret values, for example a well-known port. Supercedes
+                              FromConnectionSecretKey when set.
                             type: string
                         type: object
                       type: array
                     name:
-                      description: A Name uniquely identifies this entry within its Composition's resources array. Names are optional but *strongly* recommended. When all entries in the resources array are named entries may added, deleted, and reordered as long as their names do not change. When entries are not named the length and order of the resources array should be treated as immutable. Either all or no entries must be named.
+                      description: A Name uniquely identifies this entry within its
+                        Composition's resources array. Names are optional but *strongly*
+                        recommended. When all entries in the resources array are named
+                        entries may added, deleted, and reordered as long as their
+                        names do not change. When entries are not named the length
+                        and order of the resources array should be treated as immutable.
+                        Either all or no entries must be named.
                       type: string
                     patches:
-                      description: Patches will be applied as overlay to the base resource.
+                      description: Patches will be applied as overlay to the base
+                        resource.
                       items:
-                        description: Patch objects are applied between composite and composed resources. Their behaviour depends on the Type selected. The default Type, FromCompositeFieldPath, copies a value from the composite resource to the composed resource, applying any defined transformers.
+                        description: Patch objects are applied between composite and
+                          composed resources. Their behaviour depends on the Type
+                          selected. The default Type, FromCompositeFieldPath, copies
+                          a value from the composite resource to the composed resource,
+                          applying any defined transformers.
                         properties:
+                          combine:
+                            description: Combine is the patch configuration for a
+                              CombineFromComposite or CombineToComposite patch.
+                            properties:
+                              strategy:
+                                description: Strategy defines the strategy to use
+                                  to combine the input variable values. Currently
+                                  only string is supported.
+                                enum:
+                                - string
+                                type: string
+                              string:
+                                description: String declares that input variables
+                                  should be combined into a single string, using the
+                                  relevant settings for formatting purposes.
+                                properties:
+                                  fmt:
+                                    description: Format the input using a Go format
+                                      string. See https://golang.org/pkg/fmt/ for
+                                      details.
+                                    type: string
+                                required:
+                                - fmt
+                                type: object
+                              variables:
+                                description: Variables are the list of variables whose
+                                  values will be retrieved and combined.
+                                items:
+                                  description: A CombineVariable defines the source
+                                    of a value that is combined with others to form
+                                    and patch an output value. Currently, this only
+                                    supports retrieving values from a field path.
+                                  properties:
+                                    fromFieldPath:
+                                      description: FromFieldPath is the path of the
+                                        field on the source whose value is to be used
+                                        as input.
+                                      type: string
+                                  required:
+                                  - fromFieldPath
+                                  type: object
+                                minItems: 1
+                                type: array
+                            required:
+                            - strategy
+                            - variables
+                            type: object
                           fromFieldPath:
-                            description: FromFieldPath is the path of the field on the resource whose value is to be used as input. Required when type is FromCompositeFieldPath or ToCompositeFieldPath.
+                            description: FromFieldPath is the path of the field on
+                              the resource whose value is to be used as input. Required
+                              when type is FromCompositeFieldPath or ToCompositeFieldPath.
                             type: string
                           patchSetName:
-                            description: PatchSetName to include patches from. Required when type is PatchSet.
+                            description: PatchSetName to include patches from. Required
+                              when type is PatchSet.
                             type: string
                           policy:
-                            description: Policy configures the specifics of patching behaviour.
+                            description: Policy configures the specifics of patching
+                              behaviour.
                             properties:
                               fromFieldPath:
-                                description: FromFieldPath specifies how to patch from a field path. The default is 'Optional', which means the patch will be a no-op if the specified fromFieldPath does not exist. Use 'Required' if the patch should fail if the specified path does not exist.
+                                description: FromFieldPath specifies how to patch
+                                  from a field path. The default is 'Optional', which
+                                  means the patch will be a no-op if the specified
+                                  fromFieldPath does not exist. Use 'Required' if
+                                  the patch should fail if the specified path does
+                                  not exist.
                                 enum:
                                 - Optional
                                 - Required
                                 type: string
+                              mergeOptions:
+                                description: MergeOptions Specifies merge options
+                                  on a field path
+                                properties:
+                                  appendSlice:
+                                    description: Specifies that already existing elements
+                                      in a merged slice should be preserved
+                                    type: boolean
+                                  keepMapValues:
+                                    description: Specifies that already existing values
+                                      in a merged map should be preserved
+                                    type: boolean
+                                type: object
                             type: object
                           toFieldPath:
-                            description: ToFieldPath is the path of the field on the resource whose value will be changed with the result of transforms. Leave empty if you'd like to propagate to the same path as fromFieldPath.
+                            description: ToFieldPath is the path of the field on the
+                              resource whose value will be changed with the result
+                              of transforms. Leave empty if you'd like to propagate
+                              to the same path as fromFieldPath.
                             type: string
                           transforms:
-                            description: Transforms are the list of functions that are used as a FIFO pipe for the input to be transformed.
+                            description: Transforms are the list of functions that
+                              are used as a FIFO pipe for the input to be transformed.
                             items:
-                              description: Transform is a unit of process whose input is transformed into an output with the supplied configuration.
+                              description: Transform is a unit of process whose input
+                                is transformed into an output with the supplied configuration.
                               properties:
                                 convert:
-                                  description: Convert is used to cast the input into the given output type.
+                                  description: Convert is used to cast the input into
+                                    the given output type.
                                   properties:
                                     toType:
-                                      description: ToType is the type of the output of this transform.
+                                      description: ToType is the type of the output
+                                        of this transform.
                                       enum:
                                       - string
                                       - int
@@ -570,10 +987,12 @@ spec:
                                 map:
                                   additionalProperties:
                                     type: string
-                                  description: Map uses the input as a key in the given map and returns the value.
+                                  description: Map uses the input as a key in the
+                                    given map and returns the value.
                                   type: object
                                 math:
-                                  description: Math is used to transform the input via mathematical operations such as multiplication.
+                                  description: Math is used to transform the input
+                                    via mathematical operations such as multiplication.
                                   properties:
                                     multiply:
                                       description: Multiply the value.
@@ -581,10 +1000,15 @@ spec:
                                       type: integer
                                   type: object
                                 string:
-                                  description: String is used to transform the input into a string or a different kind of string. Note that the input does not necessarily need to be a string.
+                                  description: String is used to transform the input
+                                    into a string or a different kind of string. Note
+                                    that the input does not necessarily need to be
+                                    a string.
                                   properties:
                                     fmt:
-                                      description: Format the input using a Go format string. See https://golang.org/pkg/fmt/ for details.
+                                      description: Format the input using a Go format
+                                        string. See https://golang.org/pkg/fmt/ for
+                                        details.
                                       type: string
                                   required:
                                   - fmt
@@ -603,31 +1027,43 @@ spec:
                             type: array
                           type:
                             default: FromCompositeFieldPath
-                            description: Type sets the patching behaviour to be used. Each patch type may require its' own fields to be set on the Patch object.
+                            description: Type sets the patching behaviour to be used.
+                              Each patch type may require its' own fields to be set
+                              on the Patch object.
                             enum:
                             - FromCompositeFieldPath
                             - PatchSet
                             - ToCompositeFieldPath
+                            - CombineFromComposite
+                            - CombineToComposite
                             type: string
                         type: object
                       type: array
                     readinessChecks:
-                      description: ReadinessChecks allows users to define custom readiness checks. All checks have to return true in order for resource to be considered ready. The default readiness check is to have the "Ready" condition to be "True".
+                      description: ReadinessChecks allows users to define custom readiness
+                        checks. All checks have to return true in order for resource
+                        to be considered ready. The default readiness check is to
+                        have the "Ready" condition to be "True".
                       items:
-                        description: ReadinessCheck is used to indicate how to tell whether a resource is ready for consumption
+                        description: ReadinessCheck is used to indicate how to tell
+                          whether a resource is ready for consumption
                         properties:
                           fieldPath:
-                            description: FieldPath shows the path of the field whose value will be used.
+                            description: FieldPath shows the path of the field whose
+                              value will be used.
                             type: string
                           matchInteger:
-                            description: MatchInt is the value you'd like to match if you're using "MatchInt" type.
+                            description: MatchInt is the value you'd like to match
+                              if you're using "MatchInt" type.
                             format: int64
                             type: integer
                           matchString:
-                            description: MatchString is the value you'd like to match if you're using "MatchString" type.
+                            description: MatchString is the value you'd like to match
+                              if you're using "MatchString" type.
                             type: string
                           type:
-                            description: Type indicates the type of probe you'd like to use.
+                            description: Type indicates the type of probe you'd like
+                              to use.
                             enum:
                             - MatchString
                             - MatchInteger
@@ -643,43 +1079,13 @@ spec:
                   type: object
                 type: array
               writeConnectionSecretsToNamespace:
-                description: WriteConnectionSecretsToNamespace specifies the namespace in which the connection secrets of composite resource dynamically provisioned using this composition will be created.
+                description: WriteConnectionSecretsToNamespace specifies the namespace
+                  in which the connection secrets of composite resource dynamically
+                  provisioned using this composition will be created.
                 type: string
             required:
             - compositeTypeRef
             - resources
-            type: object
-          status:
-            description: CompositionStatus shows the observed state of the composition.
-            properties:
-              conditions:
-                description: Conditions of the resource.
-                items:
-                  description: A Condition that may apply to a resource.
-                  properties:
-                    lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
-                      format: date-time
-                      type: string
-                    message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
-                      type: string
-                    reason:
-                      description: A Reason for this condition's last transition from one status to another.
-                      type: string
-                    status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
-                      type: string
-                    type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
             type: object
         type: object
     served: true

--- a/config/crd/bases/pkg.ibm.crossplane.io_configurationrevisions.yaml
+++ b/config/crd/bases/pkg.ibm.crossplane.io_configurationrevisions.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/config/crd/bases/pkg.ibm.crossplane.io_configurationrevisions.yaml
+++ b/config/crd/bases/pkg.ibm.crossplane.io_configurationrevisions.yaml
@@ -12,6 +12,7 @@ spec:
   names:
     categories:
     - crossplane
+    - pkgrev
     kind: ConfigurationRevision
     listKind: ConfigurationRevisionList
     plural: configurationrevisions
@@ -46,10 +47,14 @@ spec:
         description: A ConfigurationRevision that has been added to Crossplane.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -57,7 +62,8 @@ spec:
             description: PackageRevisionSpec specifies the desired state of a PackageRevision.
             properties:
               controllerConfigRef:
-                description: ControllerConfigRef references a ControllerConfig resource that will be used to configure the packaged controller Deployment.
+                description: ControllerConfigRef references a ControllerConfig resource
+                  that will be used to configure the packaged controller Deployment.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -66,36 +72,50 @@ spec:
                 - name
                 type: object
               desiredState:
-                description: DesiredState of the PackageRevision. Can be either Active or Inactive.
+                description: DesiredState of the PackageRevision. Can be either Active
+                  or Inactive.
                 type: string
               ignoreCrossplaneConstraints:
                 default: false
-                description: IgnoreCrossplaneConstraints indicates to the package manager whether to honor Crossplane version constrains specified by the package. Default is false.
+                description: IgnoreCrossplaneConstraints indicates to the package
+                  manager whether to honor Crossplane version constrains specified
+                  by the package. Default is false.
                 type: boolean
               image:
-                description: Package image used by install Pod to extract package contents.
+                description: Package image used by install Pod to extract package
+                  contents.
                 type: string
               packagePullPolicy:
                 default: IfNotPresent
-                description: PackagePullPolicy defines the pull policy for the package. It is also applied to any images pulled for the package, such as a provider's controller image. Default is IfNotPresent.
+                description: PackagePullPolicy defines the pull policy for the package.
+                  It is also applied to any images pulled for the package, such as
+                  a provider's controller image. Default is IfNotPresent.
                 type: string
               packagePullSecrets:
-                description: PackagePullSecrets are named secrets in the same namespace that can be used to fetch packages from private registries. They are also applied to any images pulled for the package, such as a provider's controller image.
+                description: PackagePullSecrets are named secrets in the same namespace
+                  that can be used to fetch packages from private registries. They
+                  are also applied to any images pulled for the package, such as a
+                  provider's controller image.
                 items:
-                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 type: array
               revision:
-                description: Revision number. Indicates when the revision will be garbage collected based on the parent's RevisionHistoryLimit.
+                description: Revision number. Indicates when the revision will be
+                  garbage collected based on the parent's RevisionHistoryLimit.
                 format: int64
                 type: integer
               skipDependencyResolution:
                 default: false
-                description: SkipDependencyResolution indicates to the package manager whether to skip resolving dependencies for a package. Setting this value to true may have unintended consequences. Default is false.
+                description: SkipDependencyResolution indicates to the package manager
+                  whether to skip resolving dependencies for a package. Setting this
+                  value to true may have unintended consequences. Default is false.
                 type: boolean
             required:
             - desiredState
@@ -103,7 +123,8 @@ spec:
             - revision
             type: object
           status:
-            description: PackageRevisionStatus represents the observed state of a PackageRevision.
+            description: PackageRevisionStatus represents the observed state of a
+              PackageRevision.
             properties:
               conditions:
                 description: Conditions of the resource.
@@ -111,20 +132,25 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
                       type: string
                     reason:
-                      description: A Reason for this condition's last transition from one status to another.
+                      description: A Reason for this condition's last transition from
+                        one status to another.
                       type: string
                     status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -155,7 +181,9 @@ spec:
               objectRefs:
                 description: References to objects owned by PackageRevision.
                 items:
-                  description: A TypedReference refers to an object by Name, Kind, and APIVersion. It is commonly used to reference cluster-scoped objects or objects where the namespace is already known.
+                  description: A TypedReference refers to an object by Name, Kind,
+                    and APIVersion. It is commonly used to reference cluster-scoped
+                    objects or objects where the namespace is already known.
                   properties:
                     apiVersion:
                       description: APIVersion of the referenced object.
@@ -176,32 +204,50 @@ spec:
                   type: object
                 type: array
               permissionRequests:
-                description: PermissionRequests made by this package. The package declares that its controller needs these permissions to run. The RBAC manager is responsible for granting them.
+                description: PermissionRequests made by this package. The package
+                  declares that its controller needs these permissions to run. The
+                  RBAC manager is responsible for granting them.
                 items:
-                  description: PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
+                  description: PolicyRule holds information that describes a policy
+                    rule, but does not contain information about who the rule applies
+                    to or which namespace the rule applies to.
                   properties:
                     apiGroups:
-                      description: APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
+                      description: APIGroups is the name of the APIGroup that contains
+                        the resources.  If multiple API groups are specified, any
+                        action requested against one of the enumerated resources in
+                        any API group will be allowed.
                       items:
                         type: string
                       type: array
                     nonResourceURLs:
-                      description: NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                      description: NonResourceURLs is a set of partial urls that a
+                        user should have access to.  *s are allowed, but only as the
+                        full, final step in the path Since non-resource URLs are not
+                        namespaced, this field is only applicable for ClusterRoles
+                        referenced from a ClusterRoleBinding. Rules can either apply
+                        to API resources (such as "pods" or "secrets") or non-resource
+                        URL paths (such as "/api"),  but not both.
                       items:
                         type: string
                       type: array
                     resourceNames:
-                      description: ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+                      description: ResourceNames is an optional white list of names
+                        that the rule applies to.  An empty set means that everything
+                        is allowed.
                       items:
                         type: string
                       type: array
                     resources:
-                      description: Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
+                      description: Resources is a list of resources this rule applies
+                        to.  ResourceAll represents all resources.
                       items:
                         type: string
                       type: array
                     verbs:
-                      description: Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+                      description: Verbs is a list of Verbs that apply to ALL the
+                        ResourceKinds and AttributeRestrictions contained in this
+                        rule.  VerbAll represents all kinds.
                       items:
                         type: string
                       type: array
@@ -240,13 +286,19 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: A ConfigurationRevision that has been added to Crossplane.
+        description: 'A ConfigurationRevision that has been added to Crossplane. [DEPRECATED]:
+          Please use the identical v1 API instead. The v1beta1 API is scheduled to
+          be removed in Crossplane v1.6.'
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -254,7 +306,8 @@ spec:
             description: PackageRevisionSpec specifies the desired state of a PackageRevision.
             properties:
               controllerConfigRef:
-                description: ControllerConfigRef references a ControllerConfig resource that will be used to configure the packaged controller Deployment.
+                description: ControllerConfigRef references a ControllerConfig resource
+                  that will be used to configure the packaged controller Deployment.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -263,36 +316,50 @@ spec:
                 - name
                 type: object
               desiredState:
-                description: DesiredState of the PackageRevision. Can be either Active or Inactive.
+                description: DesiredState of the PackageRevision. Can be either Active
+                  or Inactive.
                 type: string
               ignoreCrossplaneConstraints:
                 default: false
-                description: IgnoreCrossplaneConstraints indicates to the package manager whether to honor Crossplane version constrains specified by the package. Default is false.
+                description: IgnoreCrossplaneConstraints indicates to the package
+                  manager whether to honor Crossplane version constrains specified
+                  by the package. Default is false.
                 type: boolean
               image:
-                description: Package image used by install Pod to extract package contents.
+                description: Package image used by install Pod to extract package
+                  contents.
                 type: string
               packagePullPolicy:
                 default: IfNotPresent
-                description: PackagePullPolicy defines the pull policy for the package. It is also applied to any images pulled for the package, such as a provider's controller image. Default is IfNotPresent.
+                description: PackagePullPolicy defines the pull policy for the package.
+                  It is also applied to any images pulled for the package, such as
+                  a provider's controller image. Default is IfNotPresent.
                 type: string
               packagePullSecrets:
-                description: PackagePullSecrets are named secrets in the same namespace that can be used to fetch packages from private registries. They are also applied to any images pulled for the package, such as a provider's controller image.
+                description: PackagePullSecrets are named secrets in the same namespace
+                  that can be used to fetch packages from private registries. They
+                  are also applied to any images pulled for the package, such as a
+                  provider's controller image.
                 items:
-                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 type: array
               revision:
-                description: Revision number. Indicates when the revision will be garbage collected based on the parent's RevisionHistoryLimit.
+                description: Revision number. Indicates when the revision will be
+                  garbage collected based on the parent's RevisionHistoryLimit.
                 format: int64
                 type: integer
               skipDependencyResolution:
                 default: false
-                description: SkipDependencyResolution indicates to the package manager whether to skip resolving dependencies for a package. Setting this value to true may have unintended consequences. Default is false.
+                description: SkipDependencyResolution indicates to the package manager
+                  whether to skip resolving dependencies for a package. Setting this
+                  value to true may have unintended consequences. Default is false.
                 type: boolean
             required:
             - desiredState
@@ -300,7 +367,8 @@ spec:
             - revision
             type: object
           status:
-            description: PackageRevisionStatus represents the observed state of a PackageRevision.
+            description: PackageRevisionStatus represents the observed state of a
+              PackageRevision.
             properties:
               conditions:
                 description: Conditions of the resource.
@@ -308,20 +376,25 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
                       type: string
                     reason:
-                      description: A Reason for this condition's last transition from one status to another.
+                      description: A Reason for this condition's last transition from
+                        one status to another.
                       type: string
                     status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -352,7 +425,9 @@ spec:
               objectRefs:
                 description: References to objects owned by PackageRevision.
                 items:
-                  description: A TypedReference refers to an object by Name, Kind, and APIVersion. It is commonly used to reference cluster-scoped objects or objects where the namespace is already known.
+                  description: A TypedReference refers to an object by Name, Kind,
+                    and APIVersion. It is commonly used to reference cluster-scoped
+                    objects or objects where the namespace is already known.
                   properties:
                     apiVersion:
                       description: APIVersion of the referenced object.
@@ -373,32 +448,50 @@ spec:
                   type: object
                 type: array
               permissionRequests:
-                description: PermissionRequests made by this package. The package declares that its controller needs these permissions to run. The RBAC manager is responsible for granting them.
+                description: PermissionRequests made by this package. The package
+                  declares that its controller needs these permissions to run. The
+                  RBAC manager is responsible for granting them.
                 items:
-                  description: PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
+                  description: PolicyRule holds information that describes a policy
+                    rule, but does not contain information about who the rule applies
+                    to or which namespace the rule applies to.
                   properties:
                     apiGroups:
-                      description: APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
+                      description: APIGroups is the name of the APIGroup that contains
+                        the resources.  If multiple API groups are specified, any
+                        action requested against one of the enumerated resources in
+                        any API group will be allowed.
                       items:
                         type: string
                       type: array
                     nonResourceURLs:
-                      description: NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                      description: NonResourceURLs is a set of partial urls that a
+                        user should have access to.  *s are allowed, but only as the
+                        full, final step in the path Since non-resource URLs are not
+                        namespaced, this field is only applicable for ClusterRoles
+                        referenced from a ClusterRoleBinding. Rules can either apply
+                        to API resources (such as "pods" or "secrets") or non-resource
+                        URL paths (such as "/api"),  but not both.
                       items:
                         type: string
                       type: array
                     resourceNames:
-                      description: ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+                      description: ResourceNames is an optional white list of names
+                        that the rule applies to.  An empty set means that everything
+                        is allowed.
                       items:
                         type: string
                       type: array
                     resources:
-                      description: Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
+                      description: Resources is a list of resources this rule applies
+                        to.  ResourceAll represents all resources.
                       items:
                         type: string
                       type: array
                     verbs:
-                      description: Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+                      description: Verbs is a list of Verbs that apply to ALL the
+                        ResourceKinds and AttributeRestrictions contained in this
+                        rule.  VerbAll represents all kinds.
                       items:
                         type: string
                       type: array

--- a/config/crd/bases/pkg.ibm.crossplane.io_configurations.yaml
+++ b/config/crd/bases/pkg.ibm.crossplane.io_configurations.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/config/crd/bases/pkg.ibm.crossplane.io_configurations.yaml
+++ b/config/crd/bases/pkg.ibm.crossplane.io_configurations.yaml
@@ -35,52 +35,70 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: Configuration is the CRD type for a request to add a configuration to Crossplane.
+        description: Configuration is the CRD type for a request to add a configuration
+          to Crossplane.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ConfigurationSpec specifies details about a request to install a configuration to Crossplane.
+            description: ConfigurationSpec specifies details about a request to install
+              a configuration to Crossplane.
             properties:
               ignoreCrossplaneConstraints:
                 default: false
-                description: IgnoreCrossplaneConstraints indicates to the package manager whether to honor Crossplane version constrains specified by the package. Default is false.
+                description: IgnoreCrossplaneConstraints indicates to the package
+                  manager whether to honor Crossplane version constrains specified
+                  by the package. Default is false.
                 type: boolean
               package:
                 description: Package is the name of the package that is being requested.
                 type: string
               packagePullPolicy:
                 default: IfNotPresent
-                description: PackagePullPolicy defines the pull policy for the package. Default is IfNotPresent.
+                description: PackagePullPolicy defines the pull policy for the package.
+                  Default is IfNotPresent.
                 type: string
               packagePullSecrets:
-                description: PackagePullSecrets are named secrets in the same namespace that can be used to fetch packages from private registries.
+                description: PackagePullSecrets are named secrets in the same namespace
+                  that can be used to fetch packages from private registries.
                 items:
-                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 type: array
               revisionActivationPolicy:
                 default: Automatic
-                description: RevisionActivationPolicy specifies how the package controller should update from one revision to the next. Options are Automatic or Manual. Default is Automatic.
+                description: RevisionActivationPolicy specifies how the package controller
+                  should update from one revision to the next. Options are Automatic
+                  or Manual. Default is Automatic.
                 type: string
               revisionHistoryLimit:
                 default: 1
-                description: RevisionHistoryLimit dictates how the package controller cleans up old inactive package revisions. Defaults to 1. Can be disabled by explicitly setting to 0.
+                description: RevisionHistoryLimit dictates how the package controller
+                  cleans up old inactive package revisions. Defaults to 1. Can be
+                  disabled by explicitly setting to 0.
                 format: int64
                 type: integer
               skipDependencyResolution:
                 default: false
-                description: SkipDependencyResolution indicates to the package manager whether to skip resolving dependencies for a package. Setting this value to true may have unintended consequences. Default is false.
+                description: SkipDependencyResolution indicates to the package manager
+                  whether to skip resolving dependencies for a package. Setting this
+                  value to true may have unintended consequences. Default is false.
                 type: boolean
             required:
             - package
@@ -94,20 +112,25 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
                       type: string
                     reason:
-                      description: A Reason for this condition's last transition from one status to another.
+                      description: A Reason for this condition's last transition from
+                        one status to another.
                       type: string
                     status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -117,10 +140,17 @@ spec:
                   type: object
                 type: array
               currentIdentifier:
-                description: CurrentIdentifier is the most recent package source that was used to produce a revision. The package manager uses this field to determine whether to check for package updates for a given source when packagePullPolicy is set to IfNotPresent. Manually removing this field will cause the package manager to check that the current revision is correct for the given package source.
+                description: CurrentIdentifier is the most recent package source that
+                  was used to produce a revision. The package manager uses this field
+                  to determine whether to check for package updates for a given source
+                  when packagePullPolicy is set to IfNotPresent. Manually removing
+                  this field will cause the package manager to check that the current
+                  revision is correct for the given package source.
                 type: string
               currentRevision:
-                description: CurrentRevision is the name of the current package revision. It will reflect the most up to date revision, whether it has been activated or not.
+                description: CurrentRevision is the name of the current package revision.
+                  It will reflect the most up to date revision, whether it has been
+                  activated or not.
                 type: string
             type: object
         type: object
@@ -144,52 +174,71 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Configuration is the CRD type for a request to add a configuration to Crossplane.
+        description: 'Configuration is the CRD type for a request to add a configuration
+          to Crossplane. [DEPRECATED]: Please use the identical v1 API instead. The
+          v1beta1 API is scheduled to be removed in Crossplane v1.6.'
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ConfigurationSpec specifies details about a request to install a configuration to Crossplane.
+            description: ConfigurationSpec specifies details about a request to install
+              a configuration to Crossplane.
             properties:
               ignoreCrossplaneConstraints:
                 default: false
-                description: IgnoreCrossplaneConstraints indicates to the package manager whether to honor Crossplane version constrains specified by the package. Default is false.
+                description: IgnoreCrossplaneConstraints indicates to the package
+                  manager whether to honor Crossplane version constrains specified
+                  by the package. Default is false.
                 type: boolean
               package:
                 description: Package is the name of the package that is being requested.
                 type: string
               packagePullPolicy:
                 default: IfNotPresent
-                description: PackagePullPolicy defines the pull policy for the package. Default is IfNotPresent.
+                description: PackagePullPolicy defines the pull policy for the package.
+                  Default is IfNotPresent.
                 type: string
               packagePullSecrets:
-                description: PackagePullSecrets are named secrets in the same namespace that can be used to fetch packages from private registries.
+                description: PackagePullSecrets are named secrets in the same namespace
+                  that can be used to fetch packages from private registries.
                 items:
-                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 type: array
               revisionActivationPolicy:
                 default: Automatic
-                description: RevisionActivationPolicy specifies how the package controller should update from one revision to the next. Options are Automatic or Manual. Default is Automatic.
+                description: RevisionActivationPolicy specifies how the package controller
+                  should update from one revision to the next. Options are Automatic
+                  or Manual. Default is Automatic.
                 type: string
               revisionHistoryLimit:
                 default: 1
-                description: RevisionHistoryLimit dictates how the package controller cleans up old inactive package revisions. Defaults to 1. Can be disabled by explicitly setting to 0.
+                description: RevisionHistoryLimit dictates how the package controller
+                  cleans up old inactive package revisions. Defaults to 1. Can be
+                  disabled by explicitly setting to 0.
                 format: int64
                 type: integer
               skipDependencyResolution:
                 default: false
-                description: SkipDependencyResolution indicates to the package manager whether to skip resolving dependencies for a package. Setting this value to true may have unintended consequences. Default is false.
+                description: SkipDependencyResolution indicates to the package manager
+                  whether to skip resolving dependencies for a package. Setting this
+                  value to true may have unintended consequences. Default is false.
                 type: boolean
             required:
             - package
@@ -203,20 +252,25 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
                       type: string
                     reason:
-                      description: A Reason for this condition's last transition from one status to another.
+                      description: A Reason for this condition's last transition from
+                        one status to another.
                       type: string
                     status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -226,10 +280,17 @@ spec:
                   type: object
                 type: array
               currentIdentifier:
-                description: CurrentIdentifier is the most recent package source that was used to produce a revision. The package manager uses this field to determine whether to check for package updates for a given source when packagePullPolicy is set to IfNotPresent. Manually removing this field will cause the package manager to check that the current revision is correct for the given package source.
+                description: CurrentIdentifier is the most recent package source that
+                  was used to produce a revision. The package manager uses this field
+                  to determine whether to check for package updates for a given source
+                  when packagePullPolicy is set to IfNotPresent. Manually removing
+                  this field will cause the package manager to check that the current
+                  revision is correct for the given package source.
                 type: string
               currentRevision:
-                description: CurrentRevision is the name of the current package revision. It will reflect the most up to date revision, whether it has been activated or not.
+                description: CurrentRevision is the name of the current package revision.
+                  It will reflect the most up to date revision, whether it has been
+                  activated or not.
                 type: string
             type: object
         type: object

--- a/config/crd/bases/pkg.ibm.crossplane.io_controllerconfigs.yaml
+++ b/config/crd/bases/pkg.ibm.crossplane.io_controllerconfigs.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/config/crd/bases/pkg.ibm.crossplane.io_controllerconfigs.yaml
+++ b/config/crd/bases/pkg.ibm.crossplane.io_controllerconfigs.yaml
@@ -26,43 +26,80 @@ spec:
         description: ControllerConfig is the CRD type for a packaged controller configuration.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ControllerConfigSpec specifies the configuration for a packaged controller. Values provided will override package manager defaults. Labels and annotations are passed to both the controller Deployment and ServiceAccount.
+            description: ControllerConfigSpec specifies the configuration for a packaged
+              controller. Values provided will override package manager defaults.
+              Labels and annotations are passed to both the controller Deployment
+              and ServiceAccount.
             properties:
               affinity:
                 description: If specified, the pod's scheduling constraints
                 properties:
                   nodeAffinity:
-                    description: Describes node affinity scheduling rules for the pod.
+                    description: Describes node affinity scheduling rules for the
+                      pod.
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
                         items:
-                          description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
                           properties:
                             preference:
-                              description: A node selector term, associated with the corresponding weight.
+                              description: A node selector term, associated with the
+                                corresponding weight.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements by node's labels.
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
-                                    description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector applies to.
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -72,18 +109,33 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
-                                  description: A list of node selector requirements by node's fields.
+                                  description: A list of node selector requirements
+                                    by node's fields.
                                   items:
-                                    description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector applies to.
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -94,7 +146,8 @@ spec:
                                   type: array
                               type: object
                             weight:
-                              description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -103,26 +156,50 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
                         properties:
                           nodeSelectorTerms:
-                            description: Required. A list of node selector terms. The terms are ORed.
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
                             items:
-                              description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements by node's labels.
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
-                                    description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector applies to.
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -132,18 +209,33 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
-                                  description: A list of node selector requirements by node's fields.
+                                  description: A list of node selector requirements
+                                    by node's fields.
                                   items:
-                                    description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector applies to.
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -159,32 +251,61 @@ spec:
                         type: object
                     type: object
                   podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated with the corresponding weight.
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources, in this case pods.
+                                  description: A label query over a set of resources,
+                                    in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -196,22 +317,97 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is alpha-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                 namespaces:
-                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -220,26 +416,52 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
                         items:
-                          description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
                           properties:
                             labelSelector:
-                              description: A label query over a set of resources, in this case pods.
+                              description: A label query over a set of resources,
+                                in this case pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -251,16 +473,85 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                                This field is alpha-level and is only honored when
+                                PodAffinityNamespaceSelector feature is enabled.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace"
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -268,32 +559,62 @@ spec:
                         type: array
                     type: object
                   podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated with the corresponding weight.
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources, in this case pods.
+                                  description: A label query over a set of resources,
+                                    in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -305,22 +626,97 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is alpha-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                 namespaces:
-                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -329,26 +725,52 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
                         items:
-                          description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
                           properties:
                             labelSelector:
-                              description: A label query over a set of resources, in this case pods.
+                              description: A label query over a set of resources,
+                                in this case pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -360,16 +782,85 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                                This field is alpha-level and is only honored when
+                                PodAffinityNamespaceSelector feature is enabled.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
                             namespaces:
-                              description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace"
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -378,23 +869,38 @@ spec:
                     type: object
                 type: object
               args:
-                description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                description: 'Arguments to the entrypoint. The docker image''s CMD
+                  is used if this is not provided. Variable references $(VAR_NAME)
+                  are expanded using the container''s environment. If a variable cannot
+                  be resolved, the reference in the input string will be unchanged.
+                  The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                  Escaped references will never be expanded, regardless of whether
+                  the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                 items:
                   type: string
                 type: array
               env:
-                description: List of environment variables to set in the container. Cannot be updated.
+                description: List of environment variables to set in the container.
+                  Cannot be updated.
                 items:
-                  description: EnvVar represents an environment variable present in a Container.
+                  description: EnvVar represents an environment variable present in
+                    a Container.
                   properties:
                     name:
                       description: Name of the environment variable. Must be a C_IDENTIFIER.
                       type: string
                     value:
-                      description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previous defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
+                        $$(VAR_NAME). Escaped references will never be expanded, regardless
+                        of whether the variable exists or not. Defaults to "".'
                       type: string
                     valueFrom:
-                      description: Source for the environment variable's value. Cannot be used if value is not empty.
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
                       properties:
                         configMapKeyRef:
                           description: Selects a key of a ConfigMap.
@@ -403,37 +909,49 @@ spec:
                               description: The key to select.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap or its key must be defined
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
                               type: boolean
                           required:
                           - key
                           type: object
                         fieldRef:
-                          description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
                           properties:
                             apiVersion:
-                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
                               type: string
                             fieldPath:
-                              description: Path of the field to select in the specified API version.
+                              description: Path of the field to select in the specified
+                                API version.
                               type: string
                           required:
                           - fieldPath
                           type: object
                         resourceFieldRef:
-                          description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
                           properties:
                             containerName:
-                              description: 'Container name: required for volumes, optional for env vars'
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
                               type: string
                             divisor:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Specifies the output format of the exposed resources, defaults to "1"
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             resource:
@@ -446,13 +964,16 @@ spec:
                           description: Selects a key of a secret in the pod's namespace
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must be a valid secret key.
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must be defined
+                              description: Specify whether the Secret or its key must
+                                be defined
                               type: boolean
                           required:
                           - key
@@ -463,7 +984,12 @@ spec:
                   type: object
                 type: array
               envFrom:
-                description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                description: List of sources to populate environment variables in
+                  the container. The keys defined within a source must be a C_IDENTIFIER.
+                  All invalid keys will be reported as an event when the container
+                  is starting. When a key exists in multiple sources, the value associated
+                  with the last source will take precedence. Values defined by an
+                  Env with a duplicate key will take precedence. Cannot be updated.
                 items:
                   description: EnvFromSource represents the source of a set of ConfigMaps
                   properties:
@@ -471,20 +997,23 @@ spec:
                       description: The ConfigMap to select from
                       properties:
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                         optional:
                           description: Specify whether the ConfigMap must be defined
                           type: boolean
                       type: object
                     prefix:
-                      description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                      description: An optional identifier to prepend to each key in
+                        the ConfigMap. Must be a C_IDENTIFIER.
                       type: string
                     secretRef:
                       description: The Secret to select from
                       properties:
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                         optional:
                           description: Specify whether the Secret must be defined
@@ -493,18 +1022,32 @@ spec:
                   type: object
                 type: array
               image:
-                description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                  This field is optional to allow higher level config management to
+                  default or override container images in workload controllers like
+                  Deployments and StatefulSets.'
                 type: string
               imagePullPolicy:
-                description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                  Defaults to Always if :latest tag is specified, or IfNotPresent
+                  otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                 type: string
               imagePullSecrets:
-                description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod Setting ImagePullSecrets will replace any secrets that have been propagated to a controller Deployment, typically via packagePullSecrets.'
+                description: 'ImagePullSecrets is an optional list of references to
+                  secrets in the same namespace to use for pulling any of the images
+                  used by this PodSpec. If specified, these secrets will be passed
+                  to individual puller implementations for them to use. For example,
+                  in the case of docker, only DockerConfig type secrets are honored.
+                  More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                  Setting ImagePullSecrets will replace any secrets that have been
+                  propagated to a controller Deployment, typically via packagePullSecrets.'
                 items:
-                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 type: array
@@ -514,74 +1057,140 @@ spec:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                    description: 'Annotations is an unstructured key value map stored
+                      with a resource that may be set by external tools to store and
+                      retrieve arbitrary metadata. They are not queryable and should
+                      be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: 'Map of string keys and values that can be used to
+                      organize and categorize (scope and select) objects. This will
+                      only affect labels on the pod, not the pod selector. Labels
+                      will be merged with internal labels used by crossplane, and
+                      labels with a crossplane.io key might be overwritten. More info:
+                      http://kubernetes.io/docs/user-guide/labels'
                     type: object
                 type: object
               nodeName:
-                description: NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
+                description: NodeName is a request to schedule this pod onto a specific
+                  node. If it is non-empty, the scheduler simply schedules this pod
+                  onto that node, assuming that it fits resource requirements.
                 type: string
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                description: 'NodeSelector is a selector which must be true for the
+                  pod to fit on a node. Selector which must match a node''s labels
+                  for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                 type: object
               podSecurityContext:
-                description: 'PodSecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.'
+                description: 'PodSecurityContext holds pod-level security attributes
+                  and common container settings. Optional: Defaults to empty.  See
+                  type description for default values of each field.'
                 properties:
                   fsGroup:
-                    description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
+                    description: "A special supplemental group that applies to all
+                      containers in a pod. Some volume types allow the Kubelet to
+                      change the ownership of that volume to be owned by the pod:
+                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
+                      set (new files created in the volume will be owned by FSGroup)
+                      3. The permission bits are OR'd with rw-rw---- \n If unset,
+                      the Kubelet will not modify the ownership and permissions of
+                      any volume."
                     format: int64
                     type: integer
                   fsGroupChangePolicy:
-                    description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.'
+                    description: 'fsGroupChangePolicy defines behavior of changing
+                      ownership and permission of the volume before being exposed
+                      inside Pod. This field will only apply to volume types which
+                      support fsGroup based ownership(and permissions). It will have
+                      no effect on ephemeral volume types such as: secret, configmaps
+                      and emptydir. Valid values are "OnRootMismatch" and "Always".
+                      If not specified, "Always" is used.'
                     type: string
                   runAsGroup:
-                    description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                    description: The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset. May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
                     format: int64
                     type: integer
                   runAsNonRoot:
-                    description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                    description: Indicates that the container must run as a non-root
+                      user. If true, the Kubelet will validate the image at runtime
+                      to ensure that it does not run as UID 0 (root) and fail to start
+                      the container if it does. If unset or false, no such validation
+                      will be performed. May also be set in SecurityContext.  If set
+                      in both SecurityContext and PodSecurityContext, the value specified
+                      in SecurityContext takes precedence.
                     type: boolean
                   runAsUser:
-                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                    description: The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in SecurityContext.  If set in both SecurityContext
+                      and PodSecurityContext, the value specified in SecurityContext
+                      takes precedence for that container.
                     format: int64
                     type: integer
                   seLinuxOptions:
-                    description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                    description: The SELinux context to be applied to all containers.
+                      If unspecified, the container runtime will allocate a random
+                      SELinux context for each container.  May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
                     properties:
                       level:
-                        description: Level is SELinux level label that applies to the container.
+                        description: Level is SELinux level label that applies to
+                          the container.
                         type: string
                       role:
-                        description: Role is a SELinux role label that applies to the container.
+                        description: Role is a SELinux role label that applies to
+                          the container.
                         type: string
                       type:
-                        description: Type is a SELinux type label that applies to the container.
+                        description: Type is a SELinux type label that applies to
+                          the container.
                         type: string
                       user:
-                        description: User is a SELinux user label that applies to the container.
+                        description: User is a SELinux user label that applies to
+                          the container.
                         type: string
                     type: object
                   seccompProfile:
-                    description: The seccomp options to use by the containers in this pod.
+                    description: The seccomp options to use by the containers in this
+                      pod.
                     properties:
                       localhostProfile:
-                        description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used. The profile must be
+                          preconfigured on the node to work. Must be a descending
+                          path, relative to the kubelet's configured seccomp profile
+                          location. Must only be set if type is "Localhost".
                         type: string
                       type:
-                        description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                        description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used. RuntimeDefault
+                          - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied."
                         type: string
                     required:
                     - type
                     type: object
                   supplementalGroups:
-                    description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
+                    description: A list of groups applied to the first process run
+                      in each container, in addition to the container's primary GID.  If
+                      unspecified, no groups will be added to any container.
                     items:
                       format: int64
                       type: integer
                     type: array
                   sysctls:
-                    description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
+                    description: Sysctls hold a list of namespaced sysctls used for
+                      the pod. Pods with unsupported sysctls (by the container runtime)
+                      might fail to launch.
                     items:
                       description: Sysctl defines a kernel parameter to be set
                       properties:
@@ -597,54 +1206,84 @@ spec:
                       type: object
                     type: array
                   windowsOptions:
-                    description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                    description: The Windows specific settings applied to all containers.
+                      If unspecified, the options within a container's SecurityContext
+                      will be used. If set in both SecurityContext and PodSecurityContext,
+                      the value specified in SecurityContext takes precedence.
                     properties:
                       gmsaCredentialSpec:
-                        description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                        description: GMSACredentialSpec is where the GMSA admission
+                          webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                          inlines the contents of the GMSA credential spec named by
+                          the GMSACredentialSpecName field.
                         type: string
                       gmsaCredentialSpecName:
-                        description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
                         type: string
                       runAsUserName:
-                        description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process. Defaults to the user specified
+                          in image metadata if unspecified. May also be set in PodSecurityContext.
+                          If set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
                         type: string
                     type: object
                 type: object
               ports:
                 description: List of container ports to expose on the container
                 items:
-                  description: ContainerPort represents a network port in a single container.
+                  description: ContainerPort represents a network port in a single
+                    container.
                   properties:
                     containerPort:
-                      description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                      description: Number of port to expose on the pod's IP address.
+                        This must be a valid port number, 0 < x < 65536.
                       format: int32
                       type: integer
                     hostIP:
                       description: What host IP to bind the external port to.
                       type: string
                     hostPort:
-                      description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+                      description: Number of port to expose on the host. If specified,
+                        this must be a valid port number, 0 < x < 65536. If HostNetwork
+                        is specified, this must match ContainerPort. Most containers
+                        do not need this.
                       format: int32
                       type: integer
                     name:
-                      description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+                      description: If specified, this must be an IANA_SVC_NAME and
+                        unique within the pod. Each named port in a pod must have
+                        a unique name. Name for the port that can be referred to by
+                        services.
                       type: string
                     protocol:
-                      description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                      description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults
+                        to "TCP".
                       type: string
                   required:
                   - containerPort
                   type: object
                 type: array
               priorityClassName:
-                description: If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+                description: If specified, indicates the pod's priority. "system-node-critical"
+                  and "system-cluster-critical" are two special keywords which indicate
+                  the highest priorities with the former being the highest priority.
+                  Any other name must be defined by creating a PriorityClass object
+                  with that name. If not specified, the pod priority will be default
+                  or zero if there is no default.
                 type: string
               replicas:
-                description: 'Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1. Note: If more than 1 replica is set and leader election is not enabled then controllers could conflict. Environment variable "LEADER_ELECTION" can be used to enable leader election process.'
+                description: 'Number of desired pods. This is a pointer to distinguish
+                  between explicit zero and not specified. Defaults to 1. Note: If
+                  more than 1 replica is set and leader election is not enabled then
+                  controllers could conflict. Environment variable "LEADER_ELECTION"
+                  can be used to enable leader election process.'
                 format: int32
                 type: integer
               resources:
-                description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                description: 'Compute Resources required by this container. Cannot
+                  be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                 properties:
                   limits:
                     additionalProperties:
@@ -653,7 +1292,8 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                   requests:
                     additionalProperties:
@@ -662,20 +1302,37 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               runtimeClassName:
-                description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.'
+                description: 'RuntimeClassName refers to a RuntimeClass object in
+                  the node.k8s.io group, which should be used to run this pod.  If
+                  no RuntimeClass resource matches the named class, the pod will not
+                  be run. If unset or empty, the "legacy" RuntimeClass will be used,
+                  which is an implicit class with an empty definition that uses the
+                  default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+                  This is a beta feature as of Kubernetes v1.14.'
                 type: string
               securityContext:
-                description: 'SecurityContext holds container-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.'
+                description: 'SecurityContext holds container-level security attributes
+                  and common container settings. Optional: Defaults to empty.  See
+                  type description for default values of each field.'
                 properties:
                   allowPrivilegeEscalation:
-                    description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                    description: 'AllowPrivilegeEscalation controls whether a process
+                      can gain more privileges than its parent process. This bool
+                      directly controls if the no_new_privs flag will be set on the
+                      container process. AllowPrivilegeEscalation is true always when
+                      the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                     type: boolean
                   capabilities:
-                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                    description: The capabilities to add/drop when running containers.
+                      Defaults to the default set of capabilities granted by the container
+                      runtime.
                     properties:
                       add:
                         description: Added capabilities
@@ -691,90 +1348,156 @@ spec:
                         type: array
                     type: object
                   privileged:
-                    description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                    description: Run container in privileged mode. Processes in privileged
+                      containers are essentially equivalent to root on the host. Defaults
+                      to false.
                     type: boolean
                   procMount:
-                    description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                    description: procMount denotes the type of proc mount to use for
+                      the containers. The default is DefaultProcMount which uses the
+                      container runtime defaults for readonly paths and masked paths.
+                      This requires the ProcMountType feature flag to be enabled.
                     type: string
                   readOnlyRootFilesystem:
-                    description: Whether this container has a read-only root filesystem. Default is false.
+                    description: Whether this container has a read-only root filesystem.
+                      Default is false.
                     type: boolean
                   runAsGroup:
-                    description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                    description: The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset. May also be set in PodSecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence.
                     format: int64
                     type: integer
                   runAsNonRoot:
-                    description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                    description: Indicates that the container must run as a non-root
+                      user. If true, the Kubelet will validate the image at runtime
+                      to ensure that it does not run as UID 0 (root) and fail to start
+                      the container if it does. If unset or false, no such validation
+                      will be performed. May also be set in PodSecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence.
                     type: boolean
                   runAsUser:
-                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                    description: The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in PodSecurityContext.  If set in both SecurityContext
+                      and PodSecurityContext, the value specified in SecurityContext
+                      takes precedence.
                     format: int64
                     type: integer
                   seLinuxOptions:
-                    description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                    description: The SELinux context to be applied to the container.
+                      If unspecified, the container runtime will allocate a random
+                      SELinux context for each container.  May also be set in PodSecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence.
                     properties:
                       level:
-                        description: Level is SELinux level label that applies to the container.
+                        description: Level is SELinux level label that applies to
+                          the container.
                         type: string
                       role:
-                        description: Role is a SELinux role label that applies to the container.
+                        description: Role is a SELinux role label that applies to
+                          the container.
                         type: string
                       type:
-                        description: Type is a SELinux type label that applies to the container.
+                        description: Type is a SELinux type label that applies to
+                          the container.
                         type: string
                       user:
-                        description: User is a SELinux user label that applies to the container.
+                        description: User is a SELinux user label that applies to
+                          the container.
                         type: string
                     type: object
                   seccompProfile:
-                    description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                    description: The seccomp options to use by this container. If
+                      seccomp options are provided at both the pod & container level,
+                      the container options override the pod options.
                     properties:
                       localhostProfile:
-                        description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used. The profile must be
+                          preconfigured on the node to work. Must be a descending
+                          path, relative to the kubelet's configured seccomp profile
+                          location. Must only be set if type is "Localhost".
                         type: string
                       type:
-                        description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                        description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used. RuntimeDefault
+                          - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied."
                         type: string
                     required:
                     - type
                     type: object
                   windowsOptions:
-                    description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                    description: The Windows specific settings applied to all containers.
+                      If unspecified, the options from the PodSecurityContext will
+                      be used. If set in both SecurityContext and PodSecurityContext,
+                      the value specified in SecurityContext takes precedence.
                     properties:
                       gmsaCredentialSpec:
-                        description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                        description: GMSACredentialSpec is where the GMSA admission
+                          webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                          inlines the contents of the GMSA credential spec named by
+                          the GMSACredentialSpecName field.
                         type: string
                       gmsaCredentialSpecName:
-                        description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
                         type: string
                       runAsUserName:
-                        description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process. Defaults to the user specified
+                          in image metadata if unspecified. May also be set in PodSecurityContext.
+                          If set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
                         type: string
                     type: object
                 type: object
               serviceAccountName:
-                description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                description: 'ServiceAccountName is the name of the ServiceAccount
+                  to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                 type: string
               tolerations:
                 description: If specified, the pod's tolerations.
                 items:
-                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
                   properties:
                     effect:
-                      description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
                       type: string
                     operator:
-                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
                       type: string
                   type: object
                 type: array

--- a/config/crd/bases/pkg.ibm.crossplane.io_locks.yaml
+++ b/config/crd/bases/pkg.ibm.crossplane.io_locks.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/config/crd/bases/pkg.ibm.crossplane.io_locks.yaml
+++ b/config/crd/bases/pkg.ibm.crossplane.io_locks.yaml
@@ -23,13 +23,19 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Lock is the CRD type that tracks package dependencies.
+        description: 'Lock is the CRD type that tracks package dependencies. [DEPRECATED]:
+          Please use the identical v1beta1 API instead. The v1alpha1 API is scheduled
+          to be removed in Crossplane v1.7.'
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -38,18 +44,24 @@ spec:
               description: LockPackage is a package that is in the lock.
               properties:
                 dependencies:
-                  description: Dependencies are the list of dependencies of this package. The order of the dependencies will dictate the order in which they are resolved.
+                  description: Dependencies are the list of dependencies of this package.
+                    The order of the dependencies will dictate the order in which
+                    they are resolved.
                   items:
-                    description: A Dependency is a dependency of a package in the lock.
+                    description: A Dependency is a dependency of a package in the
+                      lock.
                     properties:
                       constraints:
-                        description: Constraints is a valid semver range, which will be used to select a valid dependency version.
+                        description: Constraints is a valid semver range, which will
+                          be used to select a valid dependency version.
                         type: string
                       package:
-                        description: Package is the OCI image name without a tag or digest.
+                        description: Package is the OCI image name without a tag or
+                          digest.
                         type: string
                       type:
-                        description: Type is the type of package. Can be either Configuration or Provider.
+                        description: Type is the type of package. Can be either Configuration
+                          or Provider.
                         type: string
                     required:
                     - constraints
@@ -58,13 +70,93 @@ spec:
                     type: object
                   type: array
                 name:
-                  description: Name corresponds to the name of the package revision for this package.
+                  description: Name corresponds to the name of the package revision
+                    for this package.
                   type: string
                 source:
                   description: Source is the OCI image name without a tag or digest.
                   type: string
                 type:
-                  description: Type is the type of package. Can be either Configuration or Provider.
+                  description: Type is the type of package. Can be either Configuration
+                    or Provider.
+                  type: string
+                version:
+                  description: Version is the tag or digest of the OCI image.
+                  type: string
+              required:
+              - dependencies
+              - name
+              - source
+              - type
+              - version
+              type: object
+            type: array
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Lock is the CRD type that tracks package dependencies.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          packages:
+            items:
+              description: LockPackage is a package that is in the lock.
+              properties:
+                dependencies:
+                  description: Dependencies are the list of dependencies of this package.
+                    The order of the dependencies will dictate the order in which
+                    they are resolved.
+                  items:
+                    description: A Dependency is a dependency of a package in the
+                      lock.
+                    properties:
+                      constraints:
+                        description: Constraints is a valid semver range, which will
+                          be used to select a valid dependency version.
+                        type: string
+                      package:
+                        description: Package is the OCI image name without a tag or
+                          digest.
+                        type: string
+                      type:
+                        description: Type is the type of package. Can be either Configuration
+                          or Provider.
+                        type: string
+                    required:
+                    - constraints
+                    - package
+                    - type
+                    type: object
+                  type: array
+                name:
+                  description: Name corresponds to the name of the package revision
+                    for this package.
+                  type: string
+                source:
+                  description: Source is the OCI image name without a tag or digest.
+                  type: string
+                type:
+                  description: Type is the type of package. Can be either Configuration
+                    or Provider.
                   type: string
                 version:
                   description: Version is the tag or digest of the OCI image.

--- a/config/crd/bases/pkg.ibm.crossplane.io_providerrevisions.yaml
+++ b/config/crd/bases/pkg.ibm.crossplane.io_providerrevisions.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/config/crd/bases/pkg.ibm.crossplane.io_providerrevisions.yaml
+++ b/config/crd/bases/pkg.ibm.crossplane.io_providerrevisions.yaml
@@ -12,6 +12,7 @@ spec:
   names:
     categories:
     - crossplane
+    - pkgrev
     kind: ProviderRevision
     listKind: ProviderRevisionList
     plural: providerrevisions
@@ -46,10 +47,14 @@ spec:
         description: A ProviderRevision that has been added to Crossplane.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -57,7 +62,8 @@ spec:
             description: PackageRevisionSpec specifies the desired state of a PackageRevision.
             properties:
               controllerConfigRef:
-                description: ControllerConfigRef references a ControllerConfig resource that will be used to configure the packaged controller Deployment.
+                description: ControllerConfigRef references a ControllerConfig resource
+                  that will be used to configure the packaged controller Deployment.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -66,36 +72,50 @@ spec:
                 - name
                 type: object
               desiredState:
-                description: DesiredState of the PackageRevision. Can be either Active or Inactive.
+                description: DesiredState of the PackageRevision. Can be either Active
+                  or Inactive.
                 type: string
               ignoreCrossplaneConstraints:
                 default: false
-                description: IgnoreCrossplaneConstraints indicates to the package manager whether to honor Crossplane version constrains specified by the package. Default is false.
+                description: IgnoreCrossplaneConstraints indicates to the package
+                  manager whether to honor Crossplane version constrains specified
+                  by the package. Default is false.
                 type: boolean
               image:
-                description: Package image used by install Pod to extract package contents.
+                description: Package image used by install Pod to extract package
+                  contents.
                 type: string
               packagePullPolicy:
                 default: IfNotPresent
-                description: PackagePullPolicy defines the pull policy for the package. It is also applied to any images pulled for the package, such as a provider's controller image. Default is IfNotPresent.
+                description: PackagePullPolicy defines the pull policy for the package.
+                  It is also applied to any images pulled for the package, such as
+                  a provider's controller image. Default is IfNotPresent.
                 type: string
               packagePullSecrets:
-                description: PackagePullSecrets are named secrets in the same namespace that can be used to fetch packages from private registries. They are also applied to any images pulled for the package, such as a provider's controller image.
+                description: PackagePullSecrets are named secrets in the same namespace
+                  that can be used to fetch packages from private registries. They
+                  are also applied to any images pulled for the package, such as a
+                  provider's controller image.
                 items:
-                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 type: array
               revision:
-                description: Revision number. Indicates when the revision will be garbage collected based on the parent's RevisionHistoryLimit.
+                description: Revision number. Indicates when the revision will be
+                  garbage collected based on the parent's RevisionHistoryLimit.
                 format: int64
                 type: integer
               skipDependencyResolution:
                 default: false
-                description: SkipDependencyResolution indicates to the package manager whether to skip resolving dependencies for a package. Setting this value to true may have unintended consequences. Default is false.
+                description: SkipDependencyResolution indicates to the package manager
+                  whether to skip resolving dependencies for a package. Setting this
+                  value to true may have unintended consequences. Default is false.
                 type: boolean
             required:
             - desiredState
@@ -103,7 +123,8 @@ spec:
             - revision
             type: object
           status:
-            description: PackageRevisionStatus represents the observed state of a PackageRevision.
+            description: PackageRevisionStatus represents the observed state of a
+              PackageRevision.
             properties:
               conditions:
                 description: Conditions of the resource.
@@ -111,20 +132,25 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
                       type: string
                     reason:
-                      description: A Reason for this condition's last transition from one status to another.
+                      description: A Reason for this condition's last transition from
+                        one status to another.
                       type: string
                     status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -155,7 +181,9 @@ spec:
               objectRefs:
                 description: References to objects owned by PackageRevision.
                 items:
-                  description: A TypedReference refers to an object by Name, Kind, and APIVersion. It is commonly used to reference cluster-scoped objects or objects where the namespace is already known.
+                  description: A TypedReference refers to an object by Name, Kind,
+                    and APIVersion. It is commonly used to reference cluster-scoped
+                    objects or objects where the namespace is already known.
                   properties:
                     apiVersion:
                       description: APIVersion of the referenced object.
@@ -176,32 +204,50 @@ spec:
                   type: object
                 type: array
               permissionRequests:
-                description: PermissionRequests made by this package. The package declares that its controller needs these permissions to run. The RBAC manager is responsible for granting them.
+                description: PermissionRequests made by this package. The package
+                  declares that its controller needs these permissions to run. The
+                  RBAC manager is responsible for granting them.
                 items:
-                  description: PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
+                  description: PolicyRule holds information that describes a policy
+                    rule, but does not contain information about who the rule applies
+                    to or which namespace the rule applies to.
                   properties:
                     apiGroups:
-                      description: APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
+                      description: APIGroups is the name of the APIGroup that contains
+                        the resources.  If multiple API groups are specified, any
+                        action requested against one of the enumerated resources in
+                        any API group will be allowed.
                       items:
                         type: string
                       type: array
                     nonResourceURLs:
-                      description: NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                      description: NonResourceURLs is a set of partial urls that a
+                        user should have access to.  *s are allowed, but only as the
+                        full, final step in the path Since non-resource URLs are not
+                        namespaced, this field is only applicable for ClusterRoles
+                        referenced from a ClusterRoleBinding. Rules can either apply
+                        to API resources (such as "pods" or "secrets") or non-resource
+                        URL paths (such as "/api"),  but not both.
                       items:
                         type: string
                       type: array
                     resourceNames:
-                      description: ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+                      description: ResourceNames is an optional white list of names
+                        that the rule applies to.  An empty set means that everything
+                        is allowed.
                       items:
                         type: string
                       type: array
                     resources:
-                      description: Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
+                      description: Resources is a list of resources this rule applies
+                        to.  ResourceAll represents all resources.
                       items:
                         type: string
                       type: array
                     verbs:
-                      description: Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+                      description: Verbs is a list of Verbs that apply to ALL the
+                        ResourceKinds and AttributeRestrictions contained in this
+                        rule.  VerbAll represents all kinds.
                       items:
                         type: string
                       type: array
@@ -240,13 +286,19 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: A ProviderRevision that has been added to Crossplane.
+        description: 'A ProviderRevision that has been added to Crossplane. [DEPRECATED]:
+          Please use the identical v1 API instead. The v1beta1 API is scheduled to
+          be removed in Crossplane v1.6.'
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -254,7 +306,8 @@ spec:
             description: PackageRevisionSpec specifies the desired state of a PackageRevision.
             properties:
               controllerConfigRef:
-                description: ControllerConfigRef references a ControllerConfig resource that will be used to configure the packaged controller Deployment.
+                description: ControllerConfigRef references a ControllerConfig resource
+                  that will be used to configure the packaged controller Deployment.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -263,36 +316,50 @@ spec:
                 - name
                 type: object
               desiredState:
-                description: DesiredState of the PackageRevision. Can be either Active or Inactive.
+                description: DesiredState of the PackageRevision. Can be either Active
+                  or Inactive.
                 type: string
               ignoreCrossplaneConstraints:
                 default: false
-                description: IgnoreCrossplaneConstraints indicates to the package manager whether to honor Crossplane version constrains specified by the package. Default is false.
+                description: IgnoreCrossplaneConstraints indicates to the package
+                  manager whether to honor Crossplane version constrains specified
+                  by the package. Default is false.
                 type: boolean
               image:
-                description: Package image used by install Pod to extract package contents.
+                description: Package image used by install Pod to extract package
+                  contents.
                 type: string
               packagePullPolicy:
                 default: IfNotPresent
-                description: PackagePullPolicy defines the pull policy for the package. It is also applied to any images pulled for the package, such as a provider's controller image. Default is IfNotPresent.
+                description: PackagePullPolicy defines the pull policy for the package.
+                  It is also applied to any images pulled for the package, such as
+                  a provider's controller image. Default is IfNotPresent.
                 type: string
               packagePullSecrets:
-                description: PackagePullSecrets are named secrets in the same namespace that can be used to fetch packages from private registries. They are also applied to any images pulled for the package, such as a provider's controller image.
+                description: PackagePullSecrets are named secrets in the same namespace
+                  that can be used to fetch packages from private registries. They
+                  are also applied to any images pulled for the package, such as a
+                  provider's controller image.
                 items:
-                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 type: array
               revision:
-                description: Revision number. Indicates when the revision will be garbage collected based on the parent's RevisionHistoryLimit.
+                description: Revision number. Indicates when the revision will be
+                  garbage collected based on the parent's RevisionHistoryLimit.
                 format: int64
                 type: integer
               skipDependencyResolution:
                 default: false
-                description: SkipDependencyResolution indicates to the package manager whether to skip resolving dependencies for a package. Setting this value to true may have unintended consequences. Default is false.
+                description: SkipDependencyResolution indicates to the package manager
+                  whether to skip resolving dependencies for a package. Setting this
+                  value to true may have unintended consequences. Default is false.
                 type: boolean
             required:
             - desiredState
@@ -300,7 +367,8 @@ spec:
             - revision
             type: object
           status:
-            description: PackageRevisionStatus represents the observed state of a PackageRevision.
+            description: PackageRevisionStatus represents the observed state of a
+              PackageRevision.
             properties:
               conditions:
                 description: Conditions of the resource.
@@ -308,20 +376,25 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
                       type: string
                     reason:
-                      description: A Reason for this condition's last transition from one status to another.
+                      description: A Reason for this condition's last transition from
+                        one status to another.
                       type: string
                     status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -352,7 +425,9 @@ spec:
               objectRefs:
                 description: References to objects owned by PackageRevision.
                 items:
-                  description: A TypedReference refers to an object by Name, Kind, and APIVersion. It is commonly used to reference cluster-scoped objects or objects where the namespace is already known.
+                  description: A TypedReference refers to an object by Name, Kind,
+                    and APIVersion. It is commonly used to reference cluster-scoped
+                    objects or objects where the namespace is already known.
                   properties:
                     apiVersion:
                       description: APIVersion of the referenced object.
@@ -373,32 +448,50 @@ spec:
                   type: object
                 type: array
               permissionRequests:
-                description: PermissionRequests made by this package. The package declares that its controller needs these permissions to run. The RBAC manager is responsible for granting them.
+                description: PermissionRequests made by this package. The package
+                  declares that its controller needs these permissions to run. The
+                  RBAC manager is responsible for granting them.
                 items:
-                  description: PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
+                  description: PolicyRule holds information that describes a policy
+                    rule, but does not contain information about who the rule applies
+                    to or which namespace the rule applies to.
                   properties:
                     apiGroups:
-                      description: APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
+                      description: APIGroups is the name of the APIGroup that contains
+                        the resources.  If multiple API groups are specified, any
+                        action requested against one of the enumerated resources in
+                        any API group will be allowed.
                       items:
                         type: string
                       type: array
                     nonResourceURLs:
-                      description: NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+                      description: NonResourceURLs is a set of partial urls that a
+                        user should have access to.  *s are allowed, but only as the
+                        full, final step in the path Since non-resource URLs are not
+                        namespaced, this field is only applicable for ClusterRoles
+                        referenced from a ClusterRoleBinding. Rules can either apply
+                        to API resources (such as "pods" or "secrets") or non-resource
+                        URL paths (such as "/api"),  but not both.
                       items:
                         type: string
                       type: array
                     resourceNames:
-                      description: ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+                      description: ResourceNames is an optional white list of names
+                        that the rule applies to.  An empty set means that everything
+                        is allowed.
                       items:
                         type: string
                       type: array
                     resources:
-                      description: Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
+                      description: Resources is a list of resources this rule applies
+                        to.  ResourceAll represents all resources.
                       items:
                         type: string
                       type: array
                     verbs:
-                      description: Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+                      description: Verbs is a list of Verbs that apply to ALL the
+                        ResourceKinds and AttributeRestrictions contained in this
+                        rule.  VerbAll represents all kinds.
                       items:
                         type: string
                       type: array

--- a/config/crd/bases/pkg.ibm.crossplane.io_providers.yaml
+++ b/config/crd/bases/pkg.ibm.crossplane.io_providers.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/config/crd/bases/pkg.ibm.crossplane.io_providers.yaml
+++ b/config/crd/bases/pkg.ibm.crossplane.io_providers.yaml
@@ -38,18 +38,24 @@ spec:
         description: Provider is the CRD type for a request to add a provider to Crossplane.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ProviderSpec specifies details about a request to install a provider to Crossplane.
+            description: ProviderSpec specifies details about a request to install
+              a provider to Crossplane.
             properties:
               controllerConfigRef:
-                description: ControllerConfigRef references a ControllerConfig resource that will be used to configure the packaged controller Deployment.
+                description: ControllerConfigRef references a ControllerConfig resource
+                  that will be used to configure the packaged controller Deployment.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -59,37 +65,49 @@ spec:
                 type: object
               ignoreCrossplaneConstraints:
                 default: false
-                description: IgnoreCrossplaneConstraints indicates to the package manager whether to honor Crossplane version constrains specified by the package. Default is false.
+                description: IgnoreCrossplaneConstraints indicates to the package
+                  manager whether to honor Crossplane version constrains specified
+                  by the package. Default is false.
                 type: boolean
               package:
                 description: Package is the name of the package that is being requested.
                 type: string
               packagePullPolicy:
                 default: IfNotPresent
-                description: PackagePullPolicy defines the pull policy for the package. Default is IfNotPresent.
+                description: PackagePullPolicy defines the pull policy for the package.
+                  Default is IfNotPresent.
                 type: string
               packagePullSecrets:
-                description: PackagePullSecrets are named secrets in the same namespace that can be used to fetch packages from private registries.
+                description: PackagePullSecrets are named secrets in the same namespace
+                  that can be used to fetch packages from private registries.
                 items:
-                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 type: array
               revisionActivationPolicy:
                 default: Automatic
-                description: RevisionActivationPolicy specifies how the package controller should update from one revision to the next. Options are Automatic or Manual. Default is Automatic.
+                description: RevisionActivationPolicy specifies how the package controller
+                  should update from one revision to the next. Options are Automatic
+                  or Manual. Default is Automatic.
                 type: string
               revisionHistoryLimit:
                 default: 1
-                description: RevisionHistoryLimit dictates how the package controller cleans up old inactive package revisions. Defaults to 1. Can be disabled by explicitly setting to 0.
+                description: RevisionHistoryLimit dictates how the package controller
+                  cleans up old inactive package revisions. Defaults to 1. Can be
+                  disabled by explicitly setting to 0.
                 format: int64
                 type: integer
               skipDependencyResolution:
                 default: false
-                description: SkipDependencyResolution indicates to the package manager whether to skip resolving dependencies for a package. Setting this value to true may have unintended consequences. Default is false.
+                description: SkipDependencyResolution indicates to the package manager
+                  whether to skip resolving dependencies for a package. Setting this
+                  value to true may have unintended consequences. Default is false.
                 type: boolean
             required:
             - package
@@ -103,20 +121,25 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
                       type: string
                     reason:
-                      description: A Reason for this condition's last transition from one status to another.
+                      description: A Reason for this condition's last transition from
+                        one status to another.
                       type: string
                     status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -126,10 +149,17 @@ spec:
                   type: object
                 type: array
               currentIdentifier:
-                description: CurrentIdentifier is the most recent package source that was used to produce a revision. The package manager uses this field to determine whether to check for package updates for a given source when packagePullPolicy is set to IfNotPresent. Manually removing this field will cause the package manager to check that the current revision is correct for the given package source.
+                description: CurrentIdentifier is the most recent package source that
+                  was used to produce a revision. The package manager uses this field
+                  to determine whether to check for package updates for a given source
+                  when packagePullPolicy is set to IfNotPresent. Manually removing
+                  this field will cause the package manager to check that the current
+                  revision is correct for the given package source.
                 type: string
               currentRevision:
-                description: CurrentRevision is the name of the current package revision. It will reflect the most up to date revision, whether it has been activated or not.
+                description: CurrentRevision is the name of the current package revision.
+                  It will reflect the most up to date revision, whether it has been
+                  activated or not.
                 type: string
             type: object
         type: object
@@ -153,21 +183,29 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Provider is the CRD type for a request to add a provider to Crossplane.
+        description: 'Provider is the CRD type for a request to add a provider to
+          Crossplane. [DEPRECATED]: Please use the identical v1 API instead. The v1beta1
+          API is scheduled to be removed in Crossplane v1.6.'
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ProviderSpec specifies details about a request to install a provider to Crossplane.
+            description: ProviderSpec specifies details about a request to install
+              a provider to Crossplane.
             properties:
               controllerConfigRef:
-                description: ControllerConfigRef references a ControllerConfig resource that will be used to configure the packaged controller Deployment.
+                description: ControllerConfigRef references a ControllerConfig resource
+                  that will be used to configure the packaged controller Deployment.
                 properties:
                   name:
                     description: Name of the referenced object.
@@ -177,37 +215,49 @@ spec:
                 type: object
               ignoreCrossplaneConstraints:
                 default: false
-                description: IgnoreCrossplaneConstraints indicates to the package manager whether to honor Crossplane version constrains specified by the package. Default is false.
+                description: IgnoreCrossplaneConstraints indicates to the package
+                  manager whether to honor Crossplane version constrains specified
+                  by the package. Default is false.
                 type: boolean
               package:
                 description: Package is the name of the package that is being requested.
                 type: string
               packagePullPolicy:
                 default: IfNotPresent
-                description: PackagePullPolicy defines the pull policy for the package. Default is IfNotPresent.
+                description: PackagePullPolicy defines the pull policy for the package.
+                  Default is IfNotPresent.
                 type: string
               packagePullSecrets:
-                description: PackagePullSecrets are named secrets in the same namespace that can be used to fetch packages from private registries.
+                description: PackagePullSecrets are named secrets in the same namespace
+                  that can be used to fetch packages from private registries.
                 items:
-                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 type: array
               revisionActivationPolicy:
                 default: Automatic
-                description: RevisionActivationPolicy specifies how the package controller should update from one revision to the next. Options are Automatic or Manual. Default is Automatic.
+                description: RevisionActivationPolicy specifies how the package controller
+                  should update from one revision to the next. Options are Automatic
+                  or Manual. Default is Automatic.
                 type: string
               revisionHistoryLimit:
                 default: 1
-                description: RevisionHistoryLimit dictates how the package controller cleans up old inactive package revisions. Defaults to 1. Can be disabled by explicitly setting to 0.
+                description: RevisionHistoryLimit dictates how the package controller
+                  cleans up old inactive package revisions. Defaults to 1. Can be
+                  disabled by explicitly setting to 0.
                 format: int64
                 type: integer
               skipDependencyResolution:
                 default: false
-                description: SkipDependencyResolution indicates to the package manager whether to skip resolving dependencies for a package. Setting this value to true may have unintended consequences. Default is false.
+                description: SkipDependencyResolution indicates to the package manager
+                  whether to skip resolving dependencies for a package. Setting this
+                  value to true may have unintended consequences. Default is false.
                 type: boolean
             required:
             - package
@@ -221,20 +271,25 @@ spec:
                   description: A Condition that may apply to a resource.
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
                       type: string
                     reason:
-                      description: A Reason for this condition's last transition from one status to another.
+                      description: A Reason for this condition's last transition from
+                        one status to another.
                       type: string
                     status:
-                      description: Status of this condition; is it currently True, False, or Unknown?
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
                       type: string
                     type:
-                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
                       type: string
                   required:
                   - lastTransitionTime
@@ -244,10 +299,17 @@ spec:
                   type: object
                 type: array
               currentIdentifier:
-                description: CurrentIdentifier is the most recent package source that was used to produce a revision. The package manager uses this field to determine whether to check for package updates for a given source when packagePullPolicy is set to IfNotPresent. Manually removing this field will cause the package manager to check that the current revision is correct for the given package source.
+                description: CurrentIdentifier is the most recent package source that
+                  was used to produce a revision. The package manager uses this field
+                  to determine whether to check for package updates for a given source
+                  when packagePullPolicy is set to IfNotPresent. Manually removing
+                  this field will cause the package manager to check that the current
+                  revision is correct for the given package source.
                 type: string
               currentRevision:
-                description: CurrentRevision is the name of the current package revision. It will reflect the most up to date revision, whether it has been activated or not.
+                description: CurrentRevision is the name of the current package revision.
+                  It will reflect the most up to date revision, whether it has been
+                  activated or not.
                 type: string
             type: object
         type: object

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -3,6 +3,7 @@
 # It should be run by config/default
 resources:
 - bases/apiextensions.ibm.crossplane.io_compositeresourcedefinitions.yaml
+- bases/apiextensions.ibm.crossplane.io_compositionrevisions.yaml
 - bases/apiextensions.ibm.crossplane.io_compositions.yaml
 - bases/shim.bedrock.ibm.com_kafkaclaims.yaml
 - bases/shim.bedrock.ibm.com_kafkacomposites.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -88,6 +88,9 @@ spec:
               mountPath: /cache
           terminationMessagePolicy: File
           image: quay.io/opencloudio/ibm-crossplane-operator:1.1.0
+          args:
+            - core
+            - start
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -88,6 +88,9 @@ spec:
               mountPath: /cache
           terminationMessagePolicy: File
           image: quay.io/opencloudio/ibm-crossplane-operator:1.2.0
+          args:
+            - core
+            - start
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone


### PR DESCRIPTION
Update `ibm-crossplane-operator` to use crossplane v1.4.0:
* update bundle files.
* update `ibm-crossplane` submodule.
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/50085