### PR TITLE
Remove premissions for kubernetes.crossplane.io/Objects

### DIFF
--- a/config/rbac/clusterrole.yaml
+++ b/config/rbac/clusterrole.yaml
@@ -30,7 +30,6 @@ rules:
 - apiGroups:
   - apiextensions.ibm.crossplane.io
   - pkg.ibm.crossplane.io
-  - kubernetes.crossplane.io
   resources:
   - locks
   - compositeresourcedefinitions
@@ -40,7 +39,6 @@ rules:
   - configurations
   - configurationrevisions
   - controllerconfigs
-  - objects
   # finalizers
   - locks/finalizers
   - compositeresourcedefinitions/finalizers
@@ -50,7 +48,6 @@ rules:
   - configurations/finalizers
   - configurationrevisions/finalizers
   - controllerconfigs/finalizers
-  - objects/finalizers
   # status
   - locks/status
   - compositeresourcedefinitions/status
@@ -60,7 +57,6 @@ rules:
   - configurations/status
   - configurationrevisions/status
   - controllerconfigs/status
-  - objects/status
   verbs:
   - create
   - delete


### PR DESCRIPTION
Move creation of roles with permissions for Objects to Provider Kubernetes operator
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/51482