### PR TITLE
Update copyright year

### DIFF
--- a/.github/workflows/catsrc.yaml
+++ b/.github/workflows/catsrc.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 IBM Corporation
+# Copyright 2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021 IBM Corporation
+# Copyright 2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/common/scripts/build_catsrc.sh
+++ b/common/scripts/build_catsrc.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 #
-# Copyright 2021 IBM Corporation
+# Copyright 2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/install_crossplane.sh
+++ b/hack/install_crossplane.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2021 IBM Corporation
+# Copyright 2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
4 files were modified in 2022, copyright date was updated

Changes due to [#51738](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/51738)